### PR TITLE
Update ch3.md: missing semi-colon

### DIFF
--- a/this & object prototypes/ch3.md
+++ b/this & object prototypes/ch3.md
@@ -502,7 +502,7 @@ var myObjectIterator = (function(){
 
 			return ret;
 		}
-	}
+	};
 })();
 
 // for (var v of myObject) {


### PR DESCRIPTION
Modified ch3.md example to include semi-colon after return object
