### PR TITLE
Fix: MarkDown typo: due to this, Non-Strict mode read as Strict mode as ...

### DIFF
--- a/this & object prototypes/ch3.md
+++ b/this & object prototypes/ch3.md
@@ -615,7 +615,7 @@ When invoking `[[Put]]`, how it behaves differs based on a number of factors, in
 If the property is present, the `[[Put]]` algorithm will roughly check:
 
 1. Is the property an accessor descriptor (see "Getters & Setters" section below)? **If so, call the setter, if any.**
-2. Is the property a data descriptor with `writable` of `false`? **If so, silently fail in non-`strict mode`, or throw `TypeError` in `strict mode`.**
+2. Is the property a data descriptor with `writable` of `false`? **If so, silently fail in `non-strict mode`, or throw `TypeError` in `strict mode`.**
 3. Otherwise, set the value to the existing property as normal.
 
 If the property is not yet present on the object in question, the `[[Put]]` operation is even more nuanced and complex. We will revisit this scenario in Chapter 5 when we discuss `[[Prototype]]` to give it more clarity.


### PR DESCRIPTION
...non- was not highlighted
