### PR TITLE
Fix: markdown typo - extra`

### DIFF
--- a/this & object prototypes/ch3.md
+++ b/this & object prototypes/ch3.md
@@ -714,7 +714,7 @@ myObject.hasOwnProperty( "a" ); // true
 myObject.hasOwnProperty( "b" ); // false
 ```
 
-The `in` operator will check to see if the property is *in* the object, or if it exists at any higher level of the ``[[Prototype]]` chain object traversal (see Chapter 5). By contrast, `hasOwnProperty(..)` checks to see if *only* `myObject` has the property or not, and will *not* consult the `[[Prototype]]` chain. We'll come back to the important differences between these two operations in the Chapter 5 when we explore `[[Prototype]]`s in detail.
+The `in` operator will check to see if the property is *in* the object, or if it exists at any higher level of the `[[Prototype]]` chain object traversal (see Chapter 5). By contrast, `hasOwnProperty(..)` checks to see if *only* `myObject` has the property or not, and will *not* consult the `[[Prototype]]` chain. We'll come back to the important differences between these two operations in the Chapter 5 when we explore `[[Prototype]]`s in detail.
 
 `hasOwnProperty(..)` is accessible for all normal objects via delegation to `Object.prototype` (see Chapter 5). But it's possible to create an object that does not link to `Object.prototype` (via `Object.create(null)` -- see Chapter 5). In this case, a method call like `myObject.hasOwnProperty(..)` would fail.
 


### PR DESCRIPTION
**Confusion**
Please Check this line.
We'll come back to the important differences between these two operations in the Chapter 5 when we explore `[[Prototype]]`s in detail.

Is **`[[Prototype]]`s** in above line, same as **`myObject`'s**
if yes then it should be **`[[Prototype]]`'s** otherwise it should be **`[[Prototype]]`** withous 's'

Please check and confirm. I will fix.
