### PR TITLE
fixes some typos

### DIFF
--- a/this & object prototypes/ch6.md
+++ b/this & object prototypes/ch6.md
@@ -680,7 +680,7 @@ var controller1 = Object.create( AuthController );
 var controller2 = Object.create( AuthController );
 ```
 
-With behavior delegation, `AuthController` and `LoginController` are **just objects**, *horizontal* peers of each other, and are not arranged or related as parents and children in class-orientation. We somewhat arbitrarily chose to have `AuthController` delegate to `LoginController` -- it would have been just as vaild for the delegation to go the reverse direction.
+With behavior delegation, `AuthController` and `LoginController` are **just objects**, *horizontal* peers of each other, and are not arranged or related as parents and children in class-orientation. We somewhat arbitrarily chose to have `AuthController` delegate to `LoginController` -- it would have been just as valid for the delegation to go the reverse direction.
 
 The main takeaway from this second code listing is that we only have two entities (`LoginController` and `AuthController`), **not three** as before.
 

--- a/types & grammar/apA.md
+++ b/types & grammar/apA.md
@@ -5,7 +5,7 @@ I have many people to thank for making this book title and the overall series ha
 
 Firstly, I must thank my wife **Christen Simpson**, and my two kids **Ethan** and **Emily**, for putting up with Dad always pecking away at the computer. Even when not writing books, my obsession with JavaScript glues my eyes to the screen far more than it should. That time I borrow from my family is the reason these books can so deeply and completely explain JavaScript to you, the reader. I owe my family everything.
 
-I'd like to thank my editors at O'Reilly, namely **Simon St.Laurent** and **Brian MacDonald**, as well as the rest of the editorial and marketing staff. They are fantastic to work with, and have been especially accomodating during this experiment into "open source" book writing, editing, and production.
+I'd like to thank my editors at O'Reilly, namely **Simon St.Laurent** and **Brian MacDonald**, as well as the rest of the editorial and marketing staff. They are fantastic to work with, and have been especially accommodating during this experiment into "open source" book writing, editing, and production.
 
 Thank you to the many folks who have participated in making this book series better by providing editorial suggestions and corrections, including **Shelley Powers, Tim Ferro, Evan Borden, Forrest L Norvell, Jennifer Davis, Jesse Harlin**, and many others.
 

--- a/types & grammar/ch1.md
+++ b/types & grammar/ch1.md
@@ -3,7 +3,7 @@
 
 Most developers would tell you that a dynamic language (like JS) does not have *types*. Let's see what the authors of the ES5.1 specification have to say on the topic:
 
-> Algorithms within this specification manipulate values each of which has an associated type. The possible value types are exactly those defined in this clause. Types are further subclassified into ECMAScript language types and specification types.
+> Algorithms within this specification manipulate values each of which has an associated type. The possible value types are exactly those defined in this clause. Types are further sub classified into ECMAScript language types and specification types.
 >
 > An ECMAScript language type corresponds to values that are directly manipulated by an ECMAScript programmer using the ECMAScript language. The ECMAScript language types are Undefined, Null, Boolean, String, Number, and Object.
 
@@ -84,7 +84,7 @@ There are several special values spread across the various types which the *aler
 
 For the `undefined` type, there is one and only one value: `undefined`. For the `null` type, there is one and only one value: `null`. So for both of them, the label is both its type and its value.
 
-Both `undefined` and `null` are often taken to be interchanable as either "empty" values or "non" values. Other developers prefer to distinguish between them with nuance, like for instance:
+Both `undefined` and `null` are often taken to be interchangeable as either "empty" values or "non" values. Other developers prefer to distinguish between them with nuance, like for instance:
 
 * `null` is an empty value
 * `undefined` is a missing value


### PR DESCRIPTION
This PR fixes some typos found while reading titles 2 & 3 :
- vaild --> valid
- accomodating --> accommodating
- subclassified --> sub classified
- interchanable -> interchangeable
