### PR TITLE
Changed Markdown for HTML to get AST definition properly rendered

### DIFF
--- a/scope & closures/ch1.md
+++ b/scope & closures/ch1.md
@@ -23,7 +23,7 @@ In traditional compiled-language process, a chunk of source code, your program, 
 
     **Note:** The difference between tokenizing and lexing is subtle and academic, but it centers on whether or not these tokens are identified in a *stateless* or *stateful* way. Put simply, if the tokenizer were to invoke stateful parsing rules to figure out whether `a` should be considered a distinct token or just part of another token, *that* would be **lexing**.
 
-2. **Parsing:** taking a stream (array) of tokens and turning it into a tree of nested elements, which collectively represent the grammatical structure of the program. This tree is called an "AST" (**A**bstract **S**yntax **T**ree).
+2. **Parsing:** taking a stream (array) of tokens and turning it into a tree of nested elements, which collectively represent the grammatical structure of the program. This tree is called an "AST" (<b>A</b>bstract <b>S</b>yntax <b>T</b>ree).
 
     The tree for `var a = 2;` might start with a top-level node called `VariableDeclaration`, with a child node called `Identifier` (whose value is `a`), and another child called `AssignmentExpression` which itself has a child called `NumericLiteral` (whose value is `2`).
 


### PR DESCRIPTION
Converted the Abstract Syntax Tree definition to use HTML tags instead of Markdown, looks like github's markdown have the same issue than Stack Overflow's
- **A**bstract: A is not bold (Markdown without space)
- **A** bstract: A is bold (Markdown with space)
- <b>A</b>bstract: A is bold (HTML without space)

http://meta.stackexchange.com/questions/51404/markdown-handles-inline-bold-text-within-a-word-incorrectly
