### PR TITLE
Fixed copy & paste error: failure -> filfillment

### DIFF
--- a/async & performance/ch3.md
+++ b/async & performance/ch3.md
@@ -914,7 +914,7 @@ If a proper valid function is not passed as the fulfillment handler parameter to
 var p = Promise.resolve( 42 );
 
 p.then(
-	// assumed failure handler, if omitted or
+	// assumed fulfillment handler, if omitted or
 	// any other non-function value passed
 	// function(v) {
 	//     return v;


### PR DESCRIPTION
Instead of describing first `.then()`argument as 'fulfillment handler' a name of 'failure handler' was used probably due to copying the comment from the previous example.
