### PR TITLE
Fixing small 'contextual' typo

### DIFF
--- a/this & object prototypes/ch1.md
+++ b/this & object prototypes/ch1.md
@@ -266,7 +266,7 @@ Every time you feel yourself trying to mix lexical scope look-ups with `this`, r
 
 Having set aside various incorrect assumptions, let us now turn our attention to how the `this` mechanism really works.
 
-We said earlier that `this` is not an author-time binding but a runtime binding. It is contextual based on the conditions of the function's invocation. `this` binding has nothing to do with where a function is declared, but has instead everything to do with the manner in which the function is called.
+We said earlier that `this` is not an author-time binding but a runtime binding. It is context based on the conditions of the function's invocation. `this` binding has nothing to do with where a function is declared, but has instead everything to do with the manner in which the function is called.
 
 When a function is invoked, an activation record, otherwise known as an execution context, is created. This record contains information about where the function was called from (the call-stack), *how* the function was invoked, what parameters were passed, etc. One of the properties of this record is the `this` reference which will be used for the duration of that function's execution.
 


### PR DESCRIPTION
Hope I'm not wrong, so either missing noun or just simply `context` should work.

Thanks for your work!
