### PR TITLE
"this & object prototypes": using new empty array to apply concat method

### DIFF
--- a/this & object prototypes/ch2.md
+++ b/this & object prototypes/ch2.md
@@ -728,7 +728,7 @@ if (!Function.prototype.softBind) {
 						(typeof global !== "undefined" &&
 							this === global)
 					) ? obj : this,
-					curried.concat.apply( curried, arguments )
+					[].concat.apply( curried, arguments )
 				);
 			};
 		bound.prototype = Object.create( fn.prototype );


### PR DESCRIPTION
Seems like it doesn't make a difference whether you use existing `curried` array or a new one to apply `concat` method, but it might save the confusion and make this example easier to understand. Please let me know if I am missing something.