### PR TITLE
async+perf: add missing var in example

### DIFF
--- a/async & performance/ch3.md
+++ b/async & performance/ch3.md
@@ -492,7 +492,7 @@ var p1 = new Promise( function(resolve,reject){
 	resolve( p3 );
 } );
 
-p2 = new Promise( function(resolve,reject){
+var p2 = new Promise( function(resolve,reject){
 	resolve( "A" );
 } );
 


### PR DESCRIPTION
Just adds a missing var in the example for consistency.