### PR TITLE
types+grammar: fix typos in update foreword

### DIFF
--- a/types & grammar/foreword.md
+++ b/types & grammar/foreword.md
@@ -11,7 +11,7 @@ I tell that story because I did back then what many developers are doing today: 
 
 I'm not disparaging JavaScript toolkit use; after all, I'm a member of the MooTools JavaScript team! But the reason JavaScript toolkits are as powerful as they are is because their developers know the fundamentals, and their "gotchas," and apply them magnificently. As useful as these toolkits are, it's still incredibly important to know the basics of the language, and with books like Kyle Simpson's *"You Don't Know JS"* series, there's no excuse not to learn them.
 
-*"Types and Grammar"*, the third installment of the  series, is an excellent look at the core JavaScript fundamentals that copy and paste and JavaScript toolkits don't and could never teach you. Coercion and its pitfalls, natives as constructors, and the whole gamut of JavaScript basics are thoroughly explained with focused code examples. Like the other books in this series, Kyle cuts straight to the point: no fluff and word-smithing -- exactly the type of tech book I love.
+*"Types and Grammar,"* the third installment of the  series, is an excellent look at the core JavaScript fundamentals that copy and paste and JavaScript toolkits don't and could never teach you. Coercion and its pitfalls, natives as constructors, and the whole gamut of JavaScript basics are thoroughly explained with focused code examples. Like the other books in this series, Kyle cuts straight to the point: no fluff and word-smithing -- exactly the type of tech book I love.
 
 Enjoy Types and Grammar and don't let it get too far away from your desk!
 


### PR DESCRIPTION
to be consistent with

> "gotchas,"

although I think chapters should be in quotation marks only, not italicised - but it depends on which style guide you're following.