### PR TITLE
Typo correction for A&P chapters

### DIFF
--- a/async & performance/ch4.md
+++ b/async & performance/ch4.md
@@ -1279,7 +1279,7 @@ The only difference between this snippet and the version used earlier is the use
 
 The purpose of `yield`-delegation is mostly code organization, and in that way is symmetrical with normal function calling.
 
-Imagine two modules that respectively provide methods `foo()` and `bar()`, where `bar()` calls `foo()`. The reason the two are separate is generally because the proper organziation of code for the program calls for them to be in separate functions. For example, there may be cases where `foo()` is called standalone, and other places where `bar()` calls `foo()`.
+Imagine two modules that respectively provide methods `foo()` and `bar()`, where `bar()` calls `foo()`. The reason the two are separate is generally because the proper organization of code for the program calls for them to be in separate functions. For example, there may be cases where `foo()` is called standalone, and other places where `bar()` calls `foo()`.
 
 For all these exact same reasons, keeping generators separate aids in program readability, maintenance, and debuggability. In that respect, `yield *` is a syntactic shortcut for manually iterating over the steps of `*foo()` while inside of `*bar()`.
 

--- a/async & performance/ch5.md
+++ b/async & performance/ch5.md
@@ -137,7 +137,7 @@ Browsers that don't support Transferable Objects simply degrade to structured cl
 
 ### Shared Workers
 
-If your site or app allows for loading multiple tabs of the same page (a common feature), you may very well want to reduce the resource usage of their system by preventing duplicate dedicated Workers; the most common limited resource in this respect is a socket network connection, as browsers limit the number of simulataneous connections to a single host. Of course, limiting multiple connections from a client also eases your server resource requirements.
+If your site or app allows for loading multiple tabs of the same page (a common feature), you may very well want to reduce the resource usage of their system by preventing duplicate dedicated Workers; the most common limited resource in this respect is a socket network connection, as browsers limit the number of simultaneous connections to a single host. Of course, limiting multiple connections from a client also eases your server resource requirements.
 
 In this case, creating a single centralized Worker that all the page instances of your site or app can *share* is quite useful.
 

--- a/async & performance/ch6.md
+++ b/async & performance/ch6.md
@@ -499,7 +499,7 @@ Instead of worrying about all these microperformance nuances, we should instead 
 
 How do you know what's big picture or not? You have to first understand if your code is running on a critical path or not. If it's not on the critical path, chances are your optimizations are not worth much.
 
-Ever heard the admonition, "that's premature optimization!"? It comes from a famous quote from Donald Knuth: "premature optimization is the root of all evil.". Many developers cite this quote to suggest that most oprimizations are "premature" and are thus a waste of effort. The truth is, as usual, more nuanced.
+Ever heard the admonition, "that's premature optimization!"? It comes from a famous quote from Donald Knuth: "premature optimization is the root of all evil.". Many developers cite this quote to suggest that most optimizations are "premature" and are thus a waste of effort. The truth is, as usual, more nuanced.
 
 Here is Knuth's quote, in context:
 
@@ -616,4 +616,4 @@ It's important to get as many test results from as many different environments a
 
 Many common performance tests unfortunately obsess about irrelevant microperformance details like `x++` versus `++x`. Writing good tests means understanding how to focus on big picture concerns, like optimizing on the critical path, and avoiding falling into traps like different JS engines' implementation details.
 
-Tail call optimization (TCO) is a required optimization as of ES6 that will make some recursive patterns pratical in JS where they would have been impossible otherwise. TCO allows a function call in the *tail position* of another function to execute without needing any extra resources, which means the engine no longer needs to place arbitrary restrictions on call stack depth for recursive algorithms.
+Tail call optimization (TCO) is a required optimization as of ES6 that will make some recursive patterns practical in JS where they would have been impossible otherwise. TCO allows a function call in the *tail position* of another function to execute without needing any extra resources, which means the engine no longer needs to place arbitrary restrictions on call stack depth for recursive algorithms.


### PR DESCRIPTION
Corrects some minor typos in chapter 4, 5, and 6 in the "Async and Performance" title.

Thanks for the great resource. Cheers!