### PR TITLE
Update apA.md

### DIFF
--- a/this & object prototypes/apA.md
+++ b/this & object prototypes/apA.md
@@ -153,7 +153,7 @@ Ehh... maybe, maybe not. If you, like most JS devs, start assigning functions ar
 
 And depending on what sorts of syntactic approaches you take to these assignments, there may very well be cases where the `super` can't be properly bound (at least, not where you suspect), so you may (at time of writing, TC39 discussion is ongoing on the topic) have to manually bind `super` with `toMethod(..)` (kinda like you have to do `bind(..)` for `this` -- see Chapter 2).
 
-You're used to being able to assign around methods to different objects to *automatically* take advantage of the dynamicism of `this` via the *implicit binding* rule (see Chapter 2). But the same will likely not be true with methods that use `super`.
+You're used to being able to assign around methods to different objects to *automatically* take advantage of the dynamism of `this` via the *implicit binding* rule (see Chapter 2). But the same will likely not be true with methods that use `super`.
 
 Consider what `super` should do here (against `D` and `E`):
 
@@ -219,7 +219,7 @@ But the biggest problem of all about ES6 `class` is that all these various gotch
 
 In traditional class-oriented languages, you never adjust the definition of a class later, so the class design pattern doesn't suggest such capabilities. But **one of the most powerful parts** of JS is that it *is* dynamic, and the definition of any object is (unless you make it immutable) a fluid and mutable *thing*.
 
-`class` seems to imply you shouldn't do such things, by forcing you into the uglier `.prototype` syntax to do so, or forcing you think about `super` gotchas, etc. It also offers *very little* support for any of the pitfalls that this dynamicism can bring.
+`class` seems to imply you shouldn't do such things, by forcing you into the uglier `.prototype` syntax to do so, or forcing you think about `super` gotchas, etc. It also offers *very little* support for any of the pitfalls that this dynamism can bring.
 
 In other words, it's as if `class` is telling you: "dynamic is too hard, so it's probably not a good idea. Here's a static-looking syntax, so code your stuff statically."
 
@@ -227,7 +227,7 @@ What a sad commentary on JavaScript: **dynamic is too hard, let's pretend to be 
 
 These are the reasons why ES6 `class` is masquerading as a nice solution to syntactic headaches, but it's actually muddying the waters further and making things worse for JS and for clear and concise understanding.
 
-**Note:** If you use the `.bind(..)` utility to make a hard-bound function (see Chapter 2), the function created is not subclassable with ES6 `extend` like normal functions are.
+**Note:** If you use the `.bind(..)` utility to make a hard-bound function (see Chapter 2), the function created is not sub-classable with ES6 `extend` like normal functions are.
 
 ## Review (TL;DR)
 


### PR DESCRIPTION
suggested changes for typo's in "this & Object Prototypes":"Appendix A: ES6 class"