### PR TITLE
types+grammar: ch3, replace 'seconds' by 'milliseconds'

### DIFF
--- a/es6 & beyond/ch2.md
+++ b/es6 & beyond/ch2.md
@@ -2536,3 +2536,11 @@ a[Symbol.iterator];			// native function
 The specification uses the `@@` prefix notation to refer to the built-in symbols, the most common ones being: `@@iterator`, `@@toStringTag`, `@@toPrimitive`. Several others are defined as well, though they probably won't be used as often. See "Built-in Object Symbols" in Chapter 7 for detailed information about how these are used for metaprogramming purposes.
 
 ## Review
+
+ES6 adds a whole slew of new syntax forms to JavaScript, so there's plenty to learn!
+
+Most of these are designed to ease the pain points of common programming idioms, such as setting default values to function parameters and gathering the "rest" of the parameters into an array. Destructuring is a powerful tool for more concisely expressing assignments of values from arrays and nested objects.
+
+While features like `=>` arrow functions appear to also be all about shorter and nicer looking syntax, they actually have very specific behaviors that you should intentionally use only in appropriate situations.
+
+Expanded Unicode support, new tricks for regular expressions, and even a new primitive `symbol` type round out the syntactic evolution of ES6.

--- a/types & grammar/ch3.md
+++ b/types & grammar/ch3.md
@@ -328,7 +328,7 @@ The `Date(..)` and `Error(..)` native constructors are much more useful than the
 
 To create a date object value, you must use `new Date()`. The `Date(..)` constructor accepts optional arguments to specify the date/time to use, but if omitted, the current date/time is assumed.
 
-By far the most common reason you construct a date object is to get the current unix timestamp value (an integer number of seconds since Jan 1, 1970). You can do this by calling `getTime()` on a date object instance.
+By far the most common reason you construct a date object is to get the current unix timestamp value (an integer number of milliseconds since Jan 1, 1970). You can do this by calling `getTime()` on a date object instance.
 
 But an even easier way is to just call the static helper function defined as of ES5: `Date.now()`. And to polyfill that for pre-ES5 is pretty easy:
 


### PR DESCRIPTION
Hi,

As just a small correction, I replaced *seconds* by *milliseconds*.

See [`Date.now ( )`](http://www.ecma-international.org/ecma-262/5.1/#sec-15.9.4.4) and [**Time Values and Time Range**](http://www.ecma-international.org/ecma-262/5.1/#sec-15.9.1.1).