### PR TITLE
Fix 'accross'

### DIFF
--- a/types & grammar/ch4.md
+++ b/types & grammar/ch4.md
@@ -640,7 +640,7 @@ I find this to be cleaner code than the previous `>= 0` / `== -1` clutter.
 
 ##### Truncating Bits
 
-There's one more place `~` may show up in code you run accross: some developers use the double tilde `~~` to truncate the decimal part of a `number` (i.e., "coerce" it to a whole number "integer"). It's commonly (though mistakingly) said this is the same result as calling `Math.floor(..)`.
+There's one more place `~` may show up in code you run across: some developers use the double tilde `~~` to truncate the decimal part of a `number` (i.e., "coerce" it to a whole number "integer"). It's commonly (though mistakingly) said this is the same result as calling `Math.floor(..)`.
 
 How `~~` works is that the first `~` applies the `ToInt32` "coercion" and does the bitwise flip, and then the second `~` does another bitwise flip, flipping all the bits back to the original state. The end result is just the `ToInt32` "coercion" (aka truncation).
 


### PR DESCRIPTION
A simple typo.