### PR TITLE
es6+beyond: ch3, fixed typo in 'transpiling a generator'

### DIFF
--- a/es6 & beyond/ch3.md
+++ b/es6 & beyond/ch3.md
@@ -1059,7 +1059,8 @@ var it = foo();
 
 it.next();				// { value: 42, done: false }
 
-it.next( 10 );			// { value: undefined, done: true }
+it.next( 10 );			// 10
+						// { value: undefined, done: true }
 ```
 
 Not bad, huh!? Hopefully this exercise solidifies in your mind that generators are actually just simple syntax for state machine logic. That makes them widely applicable.

--- a/es6 & beyond/ch3.md
+++ b/es6 & beyond/ch3.md
@@ -1144,7 +1144,7 @@ Before we get into the specific syntax, it's important to understand some fairly
 
    In pre-ES6 modules, if you put a property on your public API that holds a primitive value like a number or string, that property assignment was by value-copy, and any internal update of a corresponding variable would be separate and not affect the public copy on the API object.
 
-   With ES6, exporting a local private variable, even if it currently holds a primitive string/number/etc, exports a binding to to the variable. If the module changes the  variable's value, the external import binding now resolves to that new value.
+   With ES6, exporting a local private variable, even if it currently holds a primitive string/number/etc, exports a binding to the variable. If the module changes the  variable's value, the external import binding now resolves to that new value.
 * Importing a module is the same thing as statically requesting it to load (if it hasn't already). If you're in a browser, that implies a blocking load over the network. If you're on a server (i.e., Node.js), it's a blocking load from the filesystem.
 
    However, don't panic about the performance implications. Because ES6 modules have static definitions, the import requirements can be statically scanned, and loads will happen preemptively, even before you've used the module.


### PR DESCRIPTION
First of all, I just wanted to say this is such an incredible book for any Javascript engineer, thank you so much for making this resource available for free @getify.

In your hand transpiled version of the generator, there is a `console.log( x )` that is expected to fire during `case 1`, but is not displayed in the test output

Expected:
![screen shot 2015-04-07 at 9 56 25 am](https://cloud.githubusercontent.com/assets/6980359/7028746/c689ca42-dd0c-11e4-89c1-5613854490f7.png)

Fix:
![screen shot 2015-04-07 at 9 34 02 am](https://cloud.githubusercontent.com/assets/6980359/7028749/cb1b853c-dd0c-11e4-8efe-f20a9771d70b.png)

