### PR TITLE
 Fixed onlyOne() not working as intended

### DIFF
--- a/types & grammar/ch4.md
+++ b/types & grammar/ch4.md
@@ -1060,7 +1060,7 @@ function onlyOne() {
 		// skip falsy values. same as treating
 		// them as 0's, but avoids NaN's.
 		if (arguments[i]) {
-			sum += arguments[i];
+			sum++;
 		}
 	}
 	return sum == 1;


### PR DESCRIPTION
Fixed bug in function 'onlyOne', where onlyOne(2,0,0) would return false because it was adding the (non coerced) value of the argument to the sum. Also onlyOne(2,0,-1) would return true
