### PR TITLE
Fix typo for DOM API call `document.getElementById`

### DIFF
--- a/up & going/ch2.md
+++ b/up & going/ch2.md
@@ -938,12 +938,12 @@ So far, the only things we've covered are in the JS language itself. The reality
 The most common non-JavaScript JavaScript you'll encounter is the DOM API. For example:
 
 ```js
-var el = document.getElementByID( "foo" );
+var el = document.getElementById( "foo" );
 ```
 
 The `document` variable exists as a global variable when your code is running in a browser. It's not provided by the JS engine, nor is it particularly controlled by the JavaScript specification. It takes the form of something that looks an awful lot like a normal JS `object`, but it's not really exactly that. It's a special `object,` often called a "host object."
 
-Moreover, the `getElementByID(..)` method on `document` looks like a normal JS function, but it's just a thinly exposed interface to a built-in method provided by the DOM from your browser. In some (newer-generation) browsers, this layer may also be in JS, but traditionally the DOM and its behavior is implemented in something more like C/C++.
+Moreover, the `getElementById(..)` method on `document` looks like a normal JS function, but it's just a thinly exposed interface to a built-in method provided by the DOM from your browser. In some (newer-generation) browsers, this layer may also be in JS, but traditionally the DOM and its behavior is implemented in something more like C/C++.
 
 Another example is with input/output (I/O).
 


### PR DESCRIPTION
Noticed the 'D' in `getElementById` was capitalized. This should be lowercase. 