### PR TITLE
Fix error being thrown on typeof

### DIFF
--- a/es6 & beyond/ch2.md
+++ b/es6 & beyond/ch2.md
@@ -115,7 +115,7 @@ One last gotcha: `typeof` behaves differently with *TDZ* variables than it does 
 		console.log( "cool" );
 	}
 
-	if (typeof b === "undefined") {		// TypeError!
+	if (typeof b === "undefined") {		// ReferenceError!
 		// ..
 	}
 


### PR DESCRIPTION
Doing `typeof` in the _temporal dead zone_ throws a `ReferenceError`, not a `TypeError`.

```shell
➤ node --harmony t.js
undefined
/Users/isaac/code/temp/t.js:4
  console.log( b );   // ReferenceError!
               ^
ReferenceError: b is not defined
    at Object.<anonymous> (/Users/isaac/code/temp/t.js:4:16)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Function.Module.runMain (module.js:501:10)
    at startup (node.js:129:16)
    at node.js:814:3

➤ node --harmony t.js
undefined
/Users/isaac/code/temp/t.js:5
  if (typeof b === "undefined") {
             ^
ReferenceError: b is not defined
    at Object.<anonymous> (/Users/isaac/code/temp/t.js:5:14)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Function.Module.runMain (module.js:501:10)
    at startup (node.js:129:16)
    at node.js:814:3
```