### PR TITLE
Update ch5.md Map api // includes -> has

### DIFF
--- a/es6 & beyond/ch5.md
+++ b/es6 & beyond/ch5.md
@@ -300,11 +300,11 @@ var vals = [ ...m.values() ];
 vals;							// ["foo","bar"]
 ```
 
-To determine if a value exists in a map, use the `includes(..)` method (which is the same as on standard arrays as of ES6):
+To determine if a value exists in a map, use the `has(..)` method:
 
 ```js
-m.includes( "foo" );			// true
-m.includes( "baz" );			// false
+m.has( "foo" );			// true
+m.has( "baz" );			// false
 ```
 
 As discussed in the previous section, you can iterate over a map's entries using `entries()` (or the default map iterator). Consider:


### PR DESCRIPTION
I've looked through the documentation and can't see ```.includes(..)``` ever working with maps. The polyfill for ```.includes(..)``` uses ```.length``` (not ```.size```) so perhaps that's why they opted for 'has' rather than 'includes'. 

Seems ```.includes(..)``` is only for use with strings/arrays/typed arrays.