### PR TITLE
Update ch5.md Map values .includes() example

### DIFF
--- a/es6 & beyond/ch5.md
+++ b/es6 & beyond/ch5.md
@@ -303,8 +303,8 @@ vals;							// ["foo","bar"]
 To determine if a value exists in a map, use the `includes(..)` method (which is the same as on standard arrays as of ES6):
 
 ```js
-m.includes( "foo" );			// true
-m.includes( "baz" );			// false
+vals.includes( "foo" );			// true
+vals.includes( "baz" );			// false
 ```
 
 As discussed in the previous section, you can iterate over a map's entries using `entries()` (or the default map iterator). Consider:


### PR DESCRIPTION
As far as I can tell you intended to use ```includes(..)``` on the array ```vals``` gathered from ```m.values()```.
Using ```includes()``` on the Map itself will throw a TypeError.