### PR TITLE
Corrects minor typo.

### DIFF
--- a/scope & closures/ch5.md
+++ b/scope & closures/ch5.md
@@ -577,7 +577,7 @@ console.log(
 foo.awesome(); // LET ME INTRODUCE: HIPPO
 ```
 
-**Note:** Separate files **"foo.js"** and **"bar.js"** would be need to be created, with the contents as shown in the first two snippets, respectively. Then, your program would load/import those modules to use them, as shown in the third snippet.
+**Note:** Separate files **"foo.js"** and **"bar.js"** would need to be created, with the contents as shown in the first two snippets, respectively. Then, your program would load/import those modules to use them, as shown in the third snippet.
 
 `import` imports one or more members from a module's API into the current scope, each to a bound variable (`hello` in our case). `module` imports an entire module API to a bound variable (`foo`, `bar` in our case). `export` exports an identifier (variable, function) to the public API for the current module. These operators can be used as many times in a module's definition as is necessary.
 


### PR DESCRIPTION
Omits the first occurrence of "be" from the following sentence on line 580: "**Note:** Separate files **"foo.js"** and **"bar.js"** would be need to be created..."