### PR TITLE
instructional comment corrected

### DIFF
--- a/this & object prototypes/ch2.md
+++ b/this & object prototypes/ch2.md
@@ -283,7 +283,7 @@ var bar = function() {
 bar(); // 2
 setTimeout( bar, 100 ); // 2
 
-// hard-bound `bar` can no longer have its `this` overridden
+// inside `bar`, `foo` is hard-bound to `obj` and can no longer have its `this` overridden
 bar.call( window ); // 2
 ```
 

--- a/this & object prototypes/ch2.md
+++ b/this & object prototypes/ch2.md
@@ -283,7 +283,7 @@ var bar = function() {
 bar(); // 2
 setTimeout( bar, 100 ); // 2
 
-// inside `bar`, `foo` is hard-bound to `obj` and can no longer have its `this` overridden
+// `bar` is a hard-bound version of `foo`. Any attempt to bind a different `this` will fail.
 bar.call( window ); // 2
 ```
 


### PR DESCRIPTION
Technically this comment:
// hard-bound `bar` can no longer have its `this` overridden
is incorrect.
`bar` can most definitely have its `this` overridden as the following code demonstrates:

```javascript

function foo() {
    console.log( this.a );
}

var obj = {
    a: 2
};

var obj2 = {
    a: 42
};

var bar = function() {
    foo.call( obj );
    console.log(this.a)
};

bar(); // 2
setTimeout( bar, 3000 ); // 2

// `foo` is hard-bound to `obj` inside `bar` and can no longer have its `this` overridden
// but `this` inside bar can be overridden without affecting `this` of `foo`
 
bar.call( obj2 ); // 2 // 42


```