### PR TITLE
join JSON array elements with commas

### DIFF
--- a/types & grammar/ch4.md
+++ b/types & grammar/ch4.md
@@ -166,7 +166,7 @@ var b = {
 	// probably incorrect!
 	toJSON: function(){
 		return "[" +
-			this.val.slice( 1 ).join() +
+			this.val.slice( 1 ).join(", ") +
 		"]";
 	}
 };


### PR DESCRIPTION
This comma is indeed never used (as that is the point of the example), but
the original intent was to (mistakenly) render a JSON string, and a JSON
string would join the values with a comma.