### PR TITLE
fixed logical mistake in explanation of iterator loop

### DIFF
--- a/es6 & beyond/ch3.md
+++ b/es6 & beyond/ch3.md
@@ -174,7 +174,7 @@ for (var v, res; (res = it.next()) && !res.done; ) {
 }
 ```
 
-If you look closely, you'll see that `it.next()` is called before each iteration, and then `res.done` is consulted. If `res.done` is `false`, the iteration doesn't occur.
+If you look closely, you'll see that `it.next()` is called before each iteration, and then `res.done` is consulted. If `res.done` is `true`, the statement evaluates to false and the iteration doesn't occur.
 
 Recall earlier that we suggested iterators should in general not return `done: true` along with the final intended value from the iterator. Now you can see why.
 


### PR DESCRIPTION
The description states, that `res.done` is consulted in each iteration of the `for equivalent of a for..of loop` example and if res.done is `false`, the iteration doesn't occur. In fact, it's the other way around: if `res.done` is `true`, the statement evaluates to false and the iteration doesn't occur.