### PR TITLE
fix statement about weak typing

### DIFF
--- a/up & going/ch1.md
+++ b/up & going/ch1.md
@@ -343,7 +343,7 @@ The easiest way to go about that in your program is to assign a value to a symbo
 
 In some programming languages, you declare a variable (container) to hold a specific type of value, such as `number` or `string`. *Static typing*, otherwise known as *type enforcement*, is typically cited as a benefit for program correctness by preventing unintended value conversions.
 
-Other languages emphasize types for values instead of variables. *Weak typing*, otherwise known as *dynamic typing*, allows a variable to hold any type of value at any time. It's typically cited as a benefit for program flexibility by allowing a single variable to represent a value no matter what type form that value may take at any given moment in the program's logic flow.
+Other languages emphasize types for values instead of variables. *Dynamic typing*, otherwise known as *duck typing*, allows a variable to hold any type of value at any time. It's typically cited as a benefit for program flexibility by allowing a single variable to represent a value no matter what type form that value may take at any given moment in the program's logic flow.
 
 JavaScript uses the latter approach, *dynamic typing*, meaning variables can hold values of any *type* without any *type* enforcement.
 


### PR DESCRIPTION
Weak typing is comparable to strong typing, not to static one. Language can be weakly and statically typed at the same time.

http://stackoverflow.com/questions/2351190/static-dynamic-vs-strong-weak:

> Static/Dynamic typing is about when type information is aquired (either at compile time or at runtime)
> Strong/Weak typing is about how strictly types are distinguished (e.g. whether the language tries to do implicit conversion from strings to numbers).