### PR TITLE
Fix typo in ch8: "signficantly" => "significantly"

### DIFF
--- a/es6 & beyond/ch8.md
+++ b/es6 & beyond/ch8.md
@@ -400,7 +400,7 @@ Brendan Eich made a late breaking announcement near the completion of the first 
 
 One of the strongest pressures on the recent (and near future) design changes of the JS language has been the desire that it become a more suitable target for transpilation/cross-compilation from other languages (like C/C++, ClojureScript, etc.). Obviously, performance of code running as JavaScript has been a primary concern.
 
-As discussed in the *Async & Performance* title of this series, a few years ago a group of developers at Mozilla introduced an idea to JavaScript called ASM.js. ASM.js is a subset of valid JS that most signficantly restricts certain actions that make code hard for the JS engine to optimize. The result is that ASM.js compatible code running in an ASM-aware engine can run remarkably faster, nearly on par with native optimized C equivalents. Many viewed ASM.js as the most likely backbone on which performance-hungry applications would ride in JavaScript.
+As discussed in the *Async & Performance* title of this series, a few years ago a group of developers at Mozilla introduced an idea to JavaScript called ASM.js. ASM.js is a subset of valid JS that most significantly restricts certain actions that make code hard for the JS engine to optimize. The result is that ASM.js compatible code running in an ASM-aware engine can run remarkably faster, nearly on par with native optimized C equivalents. Many viewed ASM.js as the most likely backbone on which performance-hungry applications would ride in JavaScript.
 
 In other words, all roads to running code in the browser *lead through JavaScript*.
 


### PR DESCRIPTION
Typo in Es6&beyond, ch8, line 403: "signficantly" => "significantly".
Thanks for the thorough material, best reference for JS out there!