### PR TITLE
Fix typo in ch3 (es6 & beyond)

### DIFF
--- a/es6 & beyond/ch3.md
+++ b/es6 & beyond/ch3.md
@@ -1473,7 +1473,7 @@ foo.baz();
 
 **Note:** The `* as ..` clause requires the `*` wildcard. In other words, you cannot do something like `import { bar, x } as foo from "foo"` to bring in only part of the API but still bind to the `foo` namespace. I would have liked something like that, but for ES6 it's all or nothing with the namespace import.
 
-If the module you're importing with `* as ..` has a default export, it is named `default` in the namespace specified. You can additionaly name the default import outside of the namespace binding, as a top-level identifier. Consider a `"world"` module exported as:
+If the module you're importing with `* as ..` has a default export, it is named `default` in the namespace specified. You can additionally name the default import outside of the namespace binding, as a top-level identifier. Consider a `"world"` module exported as:
 
 ```js
 export default function foo() { .. }


### PR DESCRIPTION
Typo on line 1476: "additionaly" => "additionally". Thanks again for the great material.