### PR TITLE
ACCESSORY_PRICE conditional logic leads to overdraft

### DIFF
--- a/up & going/ch1.md
+++ b/up & going/ch1.md
@@ -477,7 +477,7 @@ var amount = 99.99;
 amount = amount * 2;
 
 // can we afford the extra purchase?
-if ( amount < bank_balance ) {
+if ( amount + ACCESSORY_PRICE < bank_balance ) {
 	console.log( "I'll take the accessory!" );
 	amount = amount + ACCESSORY_PRICE;
 }


### PR DESCRIPTION
The conditional to check whether or not one can afford the additional accessory should include the accessory price, otherwise if the bank_balance was $100.00, the code would determine "I'll take the accessory" even though the new total amount is more than their bank balance.
