### PR TITLE
Remove broken link

### DIFF
--- a/async & performance/ch2.md
+++ b/async & performance/ch2.md
@@ -516,7 +516,7 @@ Another trust issue is being called "too early." In application-specific terms, 
 
 This nondeterminism around the sync-or-async behavior is almost always going to lead to very difficult to track down bugs. In some circles, the fictional insanity-inducing monster named Zalgo is used to describe the sync/async nightmares. "Don't release Zalgo!" is a common cry, and it leads to very sound advice: always invoke callbacks asynchronously, even if that's "right away" on the next turn of the event loop, so that all callbacks are predictably async.
 
-**Note:** For more information on Zalgo, see Oren Golan's "Don't Release Zalgo!" (https://github.com/oren/oren.github.io/blob/master/posts/zalgo.md) and Isaac Z. Schlueter's "Designing APIs for Asynchrony" (http://blog.izs.me/post/59142742143/designing-apis-for-asynchrony).
+**Note:** For more information on Zalgo, see Isaac Z. Schlueter's "Designing APIs for Asynchrony" (http://blog.izs.me/post/59142742143/designing-apis-for-asynchrony).
 
 Consider:
 


### PR DESCRIPTION
Remove link to "Don't Release Zalgo!" from "Async & Performance: Chapter 2: Callbacks",
because original link is broken and that post cannot be found anywhere on the Internet