### PR TITLE
Match Review Section Title to Other Books

### DIFF
--- a/types & grammar/apA.md
+++ b/types & grammar/apA.md
@@ -386,7 +386,7 @@ Examples of other limits known to exist:
 
 It's not very common at all to run into these limits, but you should be aware that limits can and do exist, and importantly that they vary between engines.
 
-## Review
+## Review (TL;DR)
 
 We know and can rely upon the fact that the JS language itself has one standard and is predictably implemented by all the modern browsers/engines. This is a very good thing!
 

--- a/types & grammar/ch1.md
+++ b/types & grammar/ch1.md
@@ -287,7 +287,7 @@ function doSomethingCool(FeatureXYZ) {
 
 There's lots of options when designing such functionality. No one pattern here is "correct" or "wrong" -- there are various tradeoffs to each approach. But overall, it's nice that the `typeof` undeclared safety guard gives us more options.
 
-## Review
+## Review (TL;DR)
 
 JavaScript has seven built-in *types*: `null`, `undefined`,  `boolean`, `number`, `string`, `object`, `symbol`. They can be identified by the `typeof` operator.
 

--- a/types & grammar/ch2.md
+++ b/types & grammar/ch2.md
@@ -972,7 +972,7 @@ Instead of using the wrapper object `Number` in this way, it's probably much bet
 
 References are quite powerful, but sometimes they get in your way, and sometimes you need them where they don't exist. The only control you have over reference vs. value-copy behavior is the type of the value itself, so you must indirectly influence the assignment/passing behavior by which value types you choose to use.
 
-## Review
+## Review (TL;DR)
 
 In JavaScript, `array`s are simply numerically indexed collections of any value-type. `string`s are somewhat "`array`-like", but they have distinct behaviors and care must be taken if you want to treat them as `array`s. Numbers in JavaScript include both "integers" and floating-point values.
 

--- a/types & grammar/ch3.md
+++ b/types & grammar/ch3.md
@@ -480,7 +480,7 @@ Also, be very careful not to use `Array.prototype` as a default value **that wil
 
 **Note:** While we're pointing out these native prototypes and some usefulness, be cautious of relying on them and even more wary of modifying them in anyway. See Appendix A "Native Prototypes" for more discussion.
 
-## Review
+## Review (TL;DR)
 
 JavaScript provides object wrappers around primitive values, known as natives (`String`, `Number`, `Boolean`, etc). These object wrappers give the values access to behaviors appropriate for each object subtype (`String#trim()` and `Array#concat(..)`).
 

--- a/types & grammar/ch4.md
+++ b/types & grammar/ch4.md
@@ -1906,7 +1906,7 @@ a < b;						// false -- string comparison!
 Number( a ) < Number( b );	// true -- number comparison!
 ```
 
-## Review
+## Review (TL;DR)
 
 In this chapter, we turned our attention to how JavaScript type conversions happen, called **coercion**, which can be characterized as either *explicit* or *implicit*.
 

--- a/types & grammar/ch5.md
+++ b/types & grammar/ch5.md
@@ -1366,7 +1366,7 @@ The way this snippet processes is that it passes through all the `case` clause m
 
 While this sort of round-about logic is clearly possible in JavaScript, there's almost no chance that it's going to make for reasonable or understandable code. Be very skeptical if you find yourself wanting to create such circular logic flow, and if you really do, make sure you include plenty of code comments to explain what you're up to!
 
-## Review
+## Review (TL;DR)
 
 JavaScript grammar has plenty of nuance that we as developers should spend a little more time paying closer attention to than we typically do. A little bit of effort goes a long way to solidifying your deeper knowledge of the language.
 


### PR DESCRIPTION
While reading I noticed the Review section titles were missing the
(TL;DR) found in previous books in the series.