### PR TITLE
Match Async Review Section Title to Other Books

### DIFF
--- a/async & performance/apA.md
+++ b/async & performance/apA.md
@@ -815,7 +815,7 @@ foo( 8, 9 )
 
 There's a lot more awesome that `runner(..)` is capable of, but we'll come back to that in Appendix B.
 
-## Review
+## Review (TL;DR)
 
 *asynquence* is a simple abstraction -- a sequence is a series of (async) steps -- on top of Promises, aimed at making working with various asynchronous patterns much easier, without any compromise in capability.
 

--- a/async & performance/apB.md
+++ b/async & performance/apB.md
@@ -824,7 +824,7 @@ If there are any remaining values in the `ch` channel at the end of the goroutin
 
 **Note:** See many more examples of using *asynquence*-flavored CSP here (https://gist.github.com/getify/e0d04f1f5aa24b1947ae).
 
-## Review
+## Review (TL;DR)
 
 Promises and generators provide the foundational building blocks upon which we can build much more sophisticated and capable asynchrony.
 

--- a/async & performance/ch1.md
+++ b/async & performance/ch1.md
@@ -880,7 +880,7 @@ While JS semantics thankfully protect us from the *observable* nightmares that c
 
 Compiler statement reordering is almost a micro-metaphor for concurrency and interaction. As a general concept, such awareness can help you understand async JS code flow issues better.
 
-## Review
+## Review (TL;DR)
 
 A JavaScript program is (practically) always broken up into two or more chunks, where the first chunk runs *now* and the next chunk runs *later*, in response to an event. Even though the program is executed chunk-by-chunk, all of them share the same access to the program scope and state, so each modification to state is made on top of the previous state.
 

--- a/async & performance/ch2.md
+++ b/async & performance/ch2.md
@@ -590,7 +590,7 @@ That's just the story, over and over again, with callbacks. They can do pretty m
 
 You might find yourself wishing for built-in APIs or other language mechanics to address these issues. Finally ES6 has arrived on the scene with some great answers, so keep reading!
 
-## Review
+## Review (TL;DR)
 
 Callbacks are the fundamental unit of asynchrony in JS. But they're not enough for the evolving landscape of async programming as JS matures.
 

--- a/async & performance/ch3.md
+++ b/async & performance/ch3.md
@@ -2121,7 +2121,7 @@ Instead, you should default to using them across the code base, and then profile
 
 Promises are a little slower, but in exchange you're getting a lot of trustability, non-Zalgo predictability, and composability built in. Maybe the limitation is not actually their performance, but your lack of perception of their benefits?
 
-## Review
+## Review (TL;DR)
 
 Promises are awesome. Use them. They solve the *inversion of control* issues that plague us with callbacks-only code.
 

--- a/async & performance/ch4.md
+++ b/async & performance/ch4.md
@@ -2234,7 +2234,7 @@ This is more work than just using a `Promise` API polyfill for pre-ES6 Promises,
 
 Once you get hooked on generators, you'll never want to go back to the hell of async spaghetti callbacks!
 
-## Review
+## Review (TL;DR)
 
 Generators are a new ES6 function type that does not run-to-completion like normal functions. Instead, the generator can be paused in mid-completion (entirely preserving its state), and it can later be resumed from where it left off.
 

--- a/async & performance/ch5.md
+++ b/async & performance/ch5.md
@@ -353,7 +353,7 @@ The first call to `fooASM(..)` is what sets up our asm.js module with its `heap`
 
 Obviously, the nature of restrictions that make asm.js code so optimizable reduces the possible uses for such code significantly. asm.js won't necessarily be a general optimization set for any given JS program. Instead, it's intended to provide an optimized way of handling specialized tasks such as intensive math operations (e.g., those used in graphics processing for games).
 
-## Review
+## Review (TL;DR)
 
 The first four chapters of this book are based on the premise that async coding patterns give you the ability to write more performant code, which is generally a very important improvement. But async behavior only gets you so far, because it's still fundamentally bound to a single event loop thread.
 

--- a/async & performance/ch6.md
+++ b/async & performance/ch6.md
@@ -606,7 +606,7 @@ If the lack of TCO in the engine would just gracefully degrade to slower perform
 
 ES6 guarantees that from now on, JS developers will be able to rely on this optimization across all ES6+ compliant browsers. That's a win for JS performance!
 
-## Review
+## Review (TL;DR)
 
 Effectively benchmarking performance of a piece of code, especially to compare it to another option for that same code to see which approach is faster, requires careful attention to detail.
 


### PR DESCRIPTION
While reading I noticed the Review section titles were missing the
(TL;DR) found in previous books in the series.

Similar issue as #556