### PR TITLE
Match ES6 Review Section Title to Other Books

### DIFF
--- a/es6 & beyond/ch1.md
+++ b/es6 & beyond/ch1.md
@@ -106,7 +106,7 @@ It is assumed that JS will continue to evolve constantly, with browsers rolling 
 
 If you decide to keep the status quo and just wait around for all browsers without a feature supported to go away before you start using the feature, you're always going to be way behind. You'll sadly be missing out on all the innovations designed to make writing JavaScript more effective, efficient, and robust.
 
-## Review
+## Review (TL;DR)
 
 ES6 (some may try to call it ES2015) is just landing as of the time of this writing, and it has lots of new stuff you need to learn!
 

--- a/es6 & beyond/ch2.md
+++ b/es6 & beyond/ch2.md
@@ -2811,7 +2811,7 @@ The specification uses the `@@` prefix notation to refer to the built-in symbols
 
 **Note:** See "Well Known Symbols" in Chapter 7 for detailed information about how these built-in symbols are used for meta programming purposes.
 
-## Review
+## Review (TL;DR)
 
 ES6 adds a heap of new syntax forms to JavaScript, so there's plenty to learn!
 

--- a/es6 & beyond/ch3.md
+++ b/es6 & beyond/ch3.md
@@ -2035,7 +2035,7 @@ y instanceof Foo;					// true
 
 The parent class `Symbol.species` does `return this` to defer to any derived class, as you'd normally expect. `Bar` then overrides to manually declare `Foo` to be used for such instance creation. Of course, a derived class can still vend instances of itself using `new this.constructor(..)`.
 
-## Review
+## Review (TL;DR)
 
 ES6 introduces several new features that aid in code organization:
 

--- a/es6 & beyond/ch4.md
+++ b/es6 & beyond/ch4.md
@@ -369,7 +369,7 @@ Essentially, anywhere that you have more than two asynchronous steps of flow con
 
 This yield-a-promise-resume-the-generator pattern is going to be so common and so powerful, the next version of JavaScript after ES6 is almost certainly going to introduce a new function type that will do it automatically without needing the run utility. We'll cover `async function`s (as they're expected to be called) in Chapter 8.
 
-## Review
+## Review (TL;DR)
 
 As JavaScript continues to mature and grow in its widespread adoption, asynchronous programming is more and more of a central concern. Callbacks are not fully sufficient for these tasks, and totally fall down the more sophisticated the need.
 

--- a/es6 & beyond/ch5.md
+++ b/es6 & beyond/ch5.md
@@ -534,7 +534,7 @@ y = null;						// `y` is GC-eligible
 
 **Warning:** WeakSet values must be objects, not primitive values as is allowed with sets.
 
-## Review
+## Review (TL;DR)
 
 ES6 defines a number of useful collections that make working with data in structured ways more efficient and effective.
 

--- a/es6 & beyond/ch6.md
+++ b/es6 & beyond/ch6.md
@@ -794,7 +794,7 @@ For all the string search/inspection methods, if you look for an empty string `"
 
 **Warning:** These methods will not by default accept a regular expression for the search string. See "Regular Expression Symbols" in Chapter 7 for information about disabling the `isRegExp` check that is performed on this first argument.
 
-## Review
+## Review (TL;DR)
 
 ES6 adds many extra API helpers on the various built-in native objects:
 

--- a/es6 & beyond/ch7.md
+++ b/es6 & beyond/ch7.md
@@ -1273,7 +1273,7 @@ Almost any recursive algorithm can be adapted to work this way. That means it's 
 
 This approach still uses a PTC, meaning that this code will *progressively enhance* from running using the loop many times (recursion batches) in an older browser to fully leveraging TCO'd recursion in an ES6+ environment. I think that's pretty cool!
 
-## Review
+## Review (TL;DR)
 
 Meta programming is when you turn the logic of your program to focus on itself (or its runtime environment), either to inspect its own structure or to modify it. The primary value of meta programming is to extend the normal mechanisms of the language to provide additional capabilities.
 

--- a/es6 & beyond/ch8.md
+++ b/es6 & beyond/ch8.md
@@ -428,7 +428,7 @@ But as time goes on, and as WASM learns new non-JS tricks, it's not too much a s
 
 What's certain is that the more real WASM becomes over time, the more it means to the trajectory and design of JavaScript. It's perhaps one of the most important "beyond ES6" topics developers should keep an eye on.
 
-## Review
+## Review (TL;DR)
 
 If all the other books in this series essentially propose this challenge, "you (may) not know JS (as much as you thought)," this book has instead suggested, "you don't know JS anymore." The book has covered a ton of new stuff added to the language in ES6. It's an exciting collection of new language features and paradigms that will forever improve our JS programs.
 


### PR DESCRIPTION
Found the same issue as #556 and #557 in the ES6 & Beyond book.

The Review section titles were missing the (TL;DR) found in previous
books in the series.