### PR TITLE
Fix Typo in Ch 2 of Types & Grammer

### DIFF
--- a/types & grammar/ch2.md
+++ b/types & grammar/ch2.md
@@ -269,7 +269,7 @@ var c = 1 / a;
 c;					// 2e-11
 ```
 
-Because `number` values can be boxed with the `Number` object wrapper (see Chapter 3), `number` values can access methods that are built into the `Number.prototype` (see Chapter 3). For example, the `toFixed(..)` method allows you specify how many fractional decimal places you'd like the value to be represented with:
+Because `number` values can be boxed with the `Number` object wrapper (see Chapter 3), `number` values can access methods that are built into the `Number.prototype` (see Chapter 3). For example, the `toFixed(..)` method allows you to specify how many fractional decimal places you'd like the value to be represented with:
 
 ```js
 var a = 42.59;


### PR DESCRIPTION
I am not an English major, but it seemed like this sentence was missing a “to”. Let me know if it should be written another way. Thanks!