### PR TITLE
simple fix for a not really module

### DIFF
--- a/scope & closures/ch5.md
+++ b/scope & closures/ch5.md
@@ -411,6 +411,8 @@ Modules are just functions, so they can receive parameters:
 
 ```js
 function CoolModule(id) {
+	var something = "cool";
+
 	function identify() {
 		console.log( id );
 	}


### PR DESCRIPTION
An object with a function property on it alone is not *really* a module. Fixing a snippet based on this assumption.