### PR TITLE
Async & Performance, Ch 2: `timeoutify()` example bug

### DIFF
--- a/async & performance/ch2.md
+++ b/async & performance/ch2.md
@@ -490,7 +490,7 @@ function timeoutify(fn,delay) {
 		// timeout hasn't happened yet?
 		if (intv) {
 			clearTimeout( intv );
-			fn.apply( this, arguments );
+			fn.apply( this, [ null ].concat( [].slice.call( arguments ) ) );
 		}
 	};
 }


### PR DESCRIPTION
The example will always log to `console.error`.

A null value must be pushed onto the front of the list in the success case so it will fail
the `err` clause in the callback.