### PR TITLE
(fix) change "which" to "that"

### DIFF
--- a/scope & closures/ch3.md
+++ b/scope & closures/ch3.md
@@ -221,7 +221,7 @@ Anonymous function expressions are quick and easy to type, and many libraries an
 
 2. Without a name, if the function needs to refer to itself, for recursion, etc., the **deprecated** `arguments.callee` reference is unfortunately required. Another example of needing to self-reference is when an event handler function wants to unbind itself after it fires.
 
-3. Anonymous functions omit a name which is often helpful in providing more readable/understandable code. A descriptive name helps self-document the code in question.
+3. Anonymous functions omit a name that is often helpful in providing more readable/understandable code. A descriptive name helps self-document the code in question.
 
 **Inline function expressions** are powerful and useful -- the question of anonymous vs. named doesn't detract from that. Providing a name for your function expression quite effectively addresses all these draw-backs, but has no tangible downsides. The best practice is to always name your function expressions:
 


### PR DESCRIPTION
This fix alters one word that potentially causes misinterpretation. The first time I read this sentence, I thought it meant: "The omission of a name is often helpful in providing more readable/understandable code." I quickly realized that this is not the case, and I believe this potential confusion can be avoided by changing "which" to "that."