### PR TITLE
Reworded so function timer is not referred to as anonymous

### DIFF
--- a/scope & closures/ch5.md
+++ b/scope & closures/ch5.md
@@ -153,7 +153,7 @@ wait( "Hello, closure!" );
 
 We take an inner function (named `timer`) and pass it to `setTimeout(..)`. But `timer` has a scope closure over the scope of `wait(..)`, indeed keeping and using a reference to the variable `message`.
 
-A thousand milliseconds after we have executed `wait(..)`, and its inner scope should otherwise be long gone, that anonymous function still has closure over that scope.
+A thousand milliseconds after we have executed `wait(..)`, and its inner scope should otherwise be long gone, that inner function `timer` still has closure over that scope.
 
 Deep down in the guts of the *Engine*, the built-in utility `setTimeout(..)` has reference to some parameter, probably called `fn` or `func` or something like that. *Engine* goes to invoke that function, which is invoking our inner `timer` function, and the lexical scope reference is still intact.
 


### PR DESCRIPTION
I don't think timer is an anonymous function in this case since it has a name. 