### PR TITLE
adding previous chapter, next chapter and table of contents links for each chapter

### DIFF
--- a/async & performance/ch1.md
+++ b/async & performance/ch1.md
@@ -1,3 +1,5 @@
+#### [Table of Contents](toc.md#table-of-contents) | [Next Chapter ⇒](ch2.md)
+
 # You Don't Know JS: Async & Performance
 # Chapter 1: Asynchrony: Now & Later
 
@@ -891,3 +893,5 @@ At any given moment, only one event can be processed from the queue at a time. W
 Concurrency is when two or more chains of events interleave over time, such that from a high-level perspective, they appear to be running *simultaneously* (even though at any given moment only one event is being processed).
 
 It's often necessary to do some form of interaction coordination between these concurrent "processes" (as distinct from operating system processes), for instance to ensure ordering or to prevent "race conditions." These "processes" can also *cooperate* by breaking themselves into smaller chunks and to allow other "process" interleaving.
+
+#### [Table of Contents](toc.md#table-of-contents) | [Next Chapter ⇒](ch2.md)

--- a/async & performance/ch2.md
+++ b/async & performance/ch2.md
@@ -1,3 +1,5 @@
+#### [⇐ Previous Chapter](ch1.md) | [Table of Contents](toc.md#table-of-contents) | [Next Chapter ⇒](ch3.md)
+
 # You Don't Know JS: Async & Performance
 # Chapter 2: Callbacks
 
@@ -605,3 +607,5 @@ Inventing ad hoc logic to solve these trust issues is possible, but it's more di
 We need a generalized solution to **all of the trust issues**, one that can be reused for as many callbacks as we create without all the extra boilerplate overhead.
 
 We need something better than callbacks. They've served us well to this point, but the *future* of JavaScript demands more sophisticated and capable async patterns. The subsequent chapters in this book will dive into those emerging evolutions.
+
+#### [⇐ Previous Chapter](ch1.md) | [Table of Contents](toc.md#table-of-contents) | [Next Chapter ⇒](ch3.md)

--- a/async & performance/ch3.md
+++ b/async & performance/ch3.md
@@ -1,3 +1,5 @@
+#### [⇐ Previous Chapter](ch2.md) | [Table of Contents](toc.md#table-of-contents) | [Next Chapter ⇒](ch4.md)
+
 # You Don't Know JS: Async & Performance
 # Chapter 3: Promises
 
@@ -2128,3 +2130,5 @@ Promises are awesome. Use them. They solve the *inversion of control* issues tha
 They don't get rid of callbacks, they just redirect the orchestration of those callbacks to a trustable intermediary mechanism that sits between us and another utility.
 
 Promise chains also begin to address (though certainly not perfectly) a better way of expressing async flow in sequential fashion, which helps our brains plan and maintain async JS code better. We'll see an even better solution to *that* problem in the next chapter!
+
+#### [⇐ Previous Chapter](ch2.md) | [Table of Contents](toc.md#table-of-contents) | [Next Chapter ⇒](ch4.md)

--- a/async & performance/ch4.md
+++ b/async & performance/ch4.md
@@ -1,3 +1,5 @@
+#### [⇐ Previous Chapter](ch3.md) | [Table of Contents](toc.md#table-of-contents) | [Next Chapter ⇒](ch5.md)
+
 # You Don't Know JS: Async & Performance
 # Chapter 4: Generators
 
@@ -2245,3 +2247,5 @@ The `yield` / `next(..)` duality is not just a control mechanism, it's actually 
 The key benefit of generators related to async flow control is that the code inside a generator expresses a sequence of steps for the task in a naturally sync/sequential fashion. The trick is that we essentially hide potential asynchrony behind the `yield` keyword -- moving the asynchrony to the code where the generator's *iterator* is controlled.
 
 In other words, generators preserve a sequential, synchronous, blocking code pattern for async code, which lets our brains reason about the code much more naturally, addressing one of the two key drawbacks of callback-based async.
+
+#### [⇐ Previous Chapter](ch3.md) | [Table of Contents](toc.md#table-of-contents) | [Next Chapter ⇒](ch5.md)

--- a/async & performance/ch5.md
+++ b/async & performance/ch5.md
@@ -1,3 +1,5 @@
+#### [⇐ Previous Chapter](ch4.md) | [Table of Contents](toc.md#table-of-contents) | [Next Chapter ⇒](ch6.md)
+
 # You Don't Know JS: Async & Performance
 # Chapter 5: Program Performance
 
@@ -366,3 +368,5 @@ SIMD proposes to map CPU-level parallel math operations to JavaScript APIs for h
 Finally, asm.js describes a small subset of JavaScript that avoids the hard-to-optimize parts of JS (like garbage collection and coercion) and lets the JS engine recognize and run such code through aggressive optimizations. asm.js could be hand authored, but that's extremely tedious and error prone, akin to hand authoring assembly language (hence the name). Instead, the main intent is that asm.js would be a good target for cross-compilation from other highly optimized program languages -- for example, Emscripten (https://github.com/kripken/emscripten/wiki) transpiling C/C++ to JavaScript.
 
 While not covered explicitly in this chapter, there are even more radical ideas under very early discussion for JavaScript, including approximations of direct threaded functionality (not just hidden behind data structure APIs). Whether that happens explicitly, or we just see more parallelism creep into JS behind the scenes, the future of more optimized program-level performance in JS looks really *promising*.
+
+#### [⇐ Previous Chapter](ch4.md) | [Table of Contents](toc.md#table-of-contents) | [Next Chapter ⇒](ch6.md)

--- a/async & performance/ch6.md
+++ b/async & performance/ch6.md
@@ -1,3 +1,5 @@
+#### [⇐ Previous Chapter](ch5.md) | [Table of Contents](toc.md#table-of-contents)
+
 # You Don't Know JS: Async & Performance
 # Chapter 6: Benchmarking & Tuning
 
@@ -617,3 +619,5 @@ It's important to get as many test results from as many different environments a
 Many common performance tests unfortunately obsess about irrelevant microperformance details like `x++` versus `++x`. Writing good tests means understanding how to focus on big picture concerns, like optimizing on the critical path, and avoiding falling into traps like different JS engines' implementation details.
 
 Tail call optimization (TCO) is a required optimization as of ES6 that will make some recursive patterns practical in JS where they would have been impossible otherwise. TCO allows a function call in the *tail position* of another function to execute without needing any extra resources, which means the engine no longer needs to place arbitrary restrictions on call stack depth for recursive algorithms.
+
+#### [⇐ Previous Chapter](ch5.md) | [Table of Contents](toc.md#table-of-contents)

--- a/es6 & beyond/ch1.md
+++ b/es6 & beyond/ch1.md
@@ -1,3 +1,5 @@
+#### [Table of Contents](toc.md#table-of-contents) | [Next Chapter ⇒](ch2.md)
+
 # You Don't Know JS: ES6 & Beyond
 # Chapter 1: ES? Now & Future
 
@@ -117,3 +119,5 @@ Now, JavaScript features land in browsers as they become ready, and it's up to y
 Whatever labels that future JavaScript adopts, it's going to move a lot quicker than it ever has before. Transpilers and shims/polyfills are important tools to keep you on the forefront of where the language is headed.
 
 If there's any narrative important to understand about the new reality for JavaScript, it's that all JS developers are strongly implored to move from the trailing edge of the curve to the leading edge. And learning ES6 is where that all starts!
+
+#### [Table of Contents](toc.md#table-of-contents) | [Next Chapter ⇒](ch2.md)

--- a/es6 & beyond/ch2.md
+++ b/es6 & beyond/ch2.md
@@ -1,3 +1,5 @@
+#### [⇐ Previous Chapter](ch1.md) | [Table of Contents](toc.md#table-of-contents) | [Next Chapter ⇒](ch3.md)
+
 # You Don't Know JS: ES6 & Beyond
 # Chapter 2: Syntax
 
@@ -2820,3 +2822,5 @@ Most of these are designed to ease the pain points of common programming idioms,
 While features like `=>` arrow functions appear to also be all about shorter and nicer-looking syntax, they actually have very specific behaviors that you should intentionally use only in appropriate situations.
 
 Expanded Unicode support, new tricks for regular expressions, and even a new primitive `symbol` type round out the syntactic evolution of ES6.
+
+#### [⇐ Previous Chapter](ch1.md) | [Table of Contents](toc.md#table-of-contents) | [Next Chapter ⇒](ch3.md)

--- a/es6 & beyond/ch3.md
+++ b/es6 & beyond/ch3.md
@@ -1,3 +1,5 @@
+#### [⇐ Previous Chapter](ch2.md) | [Table of Contents](toc.md#table-of-contents) | [Next Chapter ⇒](ch4.md)
+
 # You Don't Know JS: ES6 & Beyond
 # Chapter 3: Organization
 
@@ -2045,3 +2047,5 @@ ES6 introduces several new features that aid in code organization:
 * Classes provide cleaner syntax around prototype-based coding. The addition of `super` also solves tricky issues with relative references in the `[[Prototype]]` chain.
 
 These new tools should be your first stop when trying to improve the architecture of your JS projects by embracing ES6.
+
+#### [⇐ Previous Chapter](ch2.md) | [Table of Contents](toc.md#table-of-contents) | [Next Chapter ⇒](ch4.md)

--- a/es6 & beyond/ch4.md
+++ b/es6 & beyond/ch4.md
@@ -1,3 +1,5 @@
+#### [⇐ Previous Chapter](ch3.md) | [Table of Contents](toc.md#table-of-contents) | [Next Chapter ⇒](ch5.md)
+
 # You Don't Know JS: ES6 & Beyond
 # Chapter 4: Async Flow Control
 
@@ -378,3 +380,5 @@ Thankfully, ES6 adds Promises to address one of the major shortcomings of callba
 But it's the combination of Promises with generators that fully realizes the benefits of rearranging our async flow control code to de-emphasize and abstract away that ugly callback soup (aka "hell").
 
 Right now, we can manage these interactions with the aide of various async libraries' runners, but JavaScript is eventually going to support this interaction pattern with dedicated syntax alone!
+
+#### [⇐ Previous Chapter](ch3.md) | [Table of Contents](toc.md#table-of-contents) | [Next Chapter ⇒](ch5.md)

--- a/es6 & beyond/ch5.md
+++ b/es6 & beyond/ch5.md
@@ -1,3 +1,5 @@
+#### [⇐ Previous Chapter](ch4.md) | [Table of Contents](toc.md#table-of-contents) | [Next Chapter ⇒](ch6.md)
+
 # You Don't Know JS: ES6 & Beyond
 # Chapter 5: Collections
 
@@ -543,3 +545,5 @@ TypedArrays provide "view"s of binary data buffers that align with various integ
 Maps are key-value pairs where the key can be an object instead of just a string/primitive. Sets are unique lists of values (of any type).
 
 WeakMaps are maps where the key (object) is weakly held, so that GC is free to collect the entry if it's the last reference to an object. WeakSets are sets where the value is weakly held, again so that GC can remove the entry if it's the last reference to that object.
+
+#### [⇐ Previous Chapter](ch4.md) | [Table of Contents](toc.md#table-of-contents) | [Next Chapter ⇒](ch6.md)

--- a/es6 & beyond/ch6.md
+++ b/es6 & beyond/ch6.md
@@ -1,3 +1,5 @@
+#### [⇐ Previous Chapter](ch5.md) | [Table of Contents](toc.md#table-of-contents) | [Next Chapter ⇒](ch7.md)
+
 # You Don't Know JS: ES6 & Beyond
 # Chapter 6: API Additions
 
@@ -797,3 +799,5 @@ ES6 adds many extra API helpers on the various built-in native objects:
 * `String` adds static functions like `String.fromCodePoint(..)` and `String.raw(..)`, as well as prototype functions like `repeat(..)` and `includes(..)`.
 
 Most of these additions can be polyfilled (see ES6 Shim), and were inspired by utilities in common JS libraries/frameworks.
+
+#### [⇐ Previous Chapter](ch5.md) | [Table of Contents](toc.md#table-of-contents) | [Next Chapter ⇒](ch7.md)

--- a/es6 & beyond/ch7.md
+++ b/es6 & beyond/ch7.md
@@ -1,3 +1,5 @@
+#### [⇐ Previous Chapter](ch6.md) | [Table of Contents](toc.md#table-of-contents) | [Next Chapter ⇒](ch8.md)
+
 # You Don't Know JS: ES6 & Beyond
 # Chapter 7: Meta Programming
 
@@ -1284,3 +1286,5 @@ From function name inferences for anonymous functions to meta properties that gi
 Feature testing, even for subtle semantic behaviors like Tail Call Optimization, shifts the meta programming focus from your program to the JS engine capabilities itself. By knowing more about what the environment can do, your programs can adjust themselves to the best fit as they run.
 
 Should you meta program? My advice is: first focus on learning how the core mechanics of the language really work. But once you fully know what JS itself can do, it's time to start leveraging these powerful meta programming capabilities to push the language further!
+
+#### [⇐ Previous Chapter](ch6.md) | [Table of Contents](toc.md#table-of-contents) | [Next Chapter ⇒](ch8.md)

--- a/es6 & beyond/ch8.md
+++ b/es6 & beyond/ch8.md
@@ -1,3 +1,5 @@
+#### [⇐ Previous Chapter](ch7.md) | [Table of Contents](toc.md#table-of-contents) 
+
 # You Don't Know JS: ES6 & Beyond
 # Chapter 8: Beyond ES6
 
@@ -437,3 +439,5 @@ But JS is not done with ES6! Not even close. There's already quite a few feature
 `async function`s are powerful syntactic sugar on top of the generators + promises pattern (see Chapter 4). `Object.observe(..)` adds direct native support for observing object change events, which is critical for implementing data binding. The `**` exponentiation operator, `...` for object properties, and `Array#includes(..)` are all simple but helpful improvements to existing mechanisms. Finally, SIMD ushers in a new era in the evolution of high performance JS.
 
 Cliché as it sounds, the future of JS is really bright! The challenge of this series, and indeed of this book, is incumbent on every reader now. What are you waiting for? It's time to get learning and exploring!
+
+#### [⇐ Previous Chapter](ch7.md) | [Table of Contents](toc.md#table-of-contents) 

--- a/scope & closures/ch1.md
+++ b/scope & closures/ch1.md
@@ -1,3 +1,5 @@
+#### [Table of Contents](toc.md#table-of-contents) | [Next Chapter ⇒](ch2.md)
+
 # You Don't Know JS: Scope & Closures
 # Chapter 1: What is Scope?
 
@@ -308,3 +310,5 @@ var c = foo( 2 );
 
 
 [^note-strictmode]: MDN: [Strict Mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions_and_function_scope/Strict_mode)
+
+#### [Table of Contents](toc.md#table-of-contents) | [Next Chapter ⇒](ch2.md)

--- a/scope & closures/ch2.md
+++ b/scope & closures/ch2.md
@@ -1,3 +1,5 @@
+#### [⇐ Previous Chapter](ch1.md) | [Table of Contents](toc.md#table-of-contents) | [Next Chapter ⇒](ch3.md)
+
 # You Don't Know JS: Scope & Closures
 # Chapter 2: Lexical Scope
 
@@ -221,3 +223,5 @@ Lexical scope means that scope is defined by author-time decisions of where func
 Two mechanisms in JavaScript can "cheat" lexical scope: `eval(..)` and `with`. The former can modify existing lexical scope (at runtime) by evaluating a string of "code" which has one or more declarations in it. The latter essentially creates a whole new lexical scope (again, at runtime) by treating an object reference *as* a "scope" and that object's properties as scoped identifiers.
 
 The downside to these mechanisms is that it defeats the *Engine*'s ability to perform compile-time optimizations regarding scope look-up, because the *Engine* has to assume pessimistically that such optimizations will be invalid. Code *will* run slower as a result of using either feature. **Don't use them.**
+
+#### [⇐ Previous Chapter](ch1.md) | [Table of Contents](toc.md#table-of-contents) | [Next Chapter ⇒](ch3.md)

--- a/scope & closures/ch3.md
+++ b/scope & closures/ch3.md
@@ -1,3 +1,5 @@
+#### [⇐ Previous Chapter](ch2.md) | [Table of Contents](toc.md#table-of-contents) | [Next Chapter ⇒](ch4.md)
+
 # You Don't Know JS: Scope & Closures
 # Chapter 3: Function vs. Block Scope
 
@@ -609,3 +611,5 @@ In ES6, the `let` keyword (a cousin to the `var` keyword) is introduced to allow
 Though some seem to believe so, block scope should not be taken as an outright replacement of `var` function scope. Both functionalities co-exist, and developers can and should use both function-scope and block-scope techniques where respectively appropriate to produce better, more readable/maintainable code.
 
 [^note-leastprivilege]: [Principle of Least Privilege](http://en.wikipedia.org/wiki/Principle_of_least_privilege)
+
+#### [⇐ Previous Chapter](ch2.md) | [Table of Contents](toc.md#table-of-contents) | [Next Chapter ⇒](ch4.md)

--- a/scope & closures/ch4.md
+++ b/scope & closures/ch4.md
@@ -1,3 +1,5 @@
+#### [⇐ Previous Chapter](ch3.md) | [Table of Contents](toc.md#table-of-contents) | [Next Chapter ⇒](ch5.md)
+
 # You Don't Know JS: Scope & Closures
 # Chapter 4: Hoisting
 
@@ -219,3 +221,5 @@ What this leads to is that all declarations in a scope, regardless of where they
 Declarations themselves are hoisted, but assignments, even assignments of function expressions, are *not* hoisted.
 
 Be careful about duplicate declarations, especially mixed between normal var declarations and function declarations -- peril awaits if you do!
+
+#### [⇐ Previous Chapter](ch3.md) | [Table of Contents](toc.md#table-of-contents) | [Next Chapter ⇒](ch5.md)

--- a/scope & closures/ch5.md
+++ b/scope & closures/ch5.md
@@ -1,3 +1,5 @@
+#### [⇐ Previous Chapter](ch4.md) | [Table of Contents](toc.md#table-of-contents) 
+
 # You Don't Know JS: Scope & Closures
 # Chapter 5: Scope Closure
 
@@ -594,3 +596,5 @@ Closures can trip us up, for instance with loops, if we're not careful to recogn
 Modules require two key characteristics: 1) an outer wrapping function being invoked, to create the enclosing scope 2) the return value of the wrapping function must include reference to at least one inner function that then has closure over the private inner scope of the wrapper.
 
 Now we can see closures all around our existing code, and we have the ability to recognize and leverage them to our own benefit!
+
+#### [⇐ Previous Chapter](ch4.md) | [Table of Contents](toc.md#table-of-contents) 

--- a/this & object prototypes/ch1.md
+++ b/this & object prototypes/ch1.md
@@ -1,3 +1,5 @@
+#### [Table of Contents](toc.md#table-of-contents) | [Next Chapter ⇒](ch2.md)
+
 # You Don't Know JS: *this* & Object Prototypes
 # Chapter 1: `this` Or That?
 
@@ -279,3 +281,5 @@ In the next chapter, we will learn to find a function's **call-site** to determi
 To learn `this`, you first have to learn what `this` is *not*, despite any assumptions or misconceptions that may lead you down those paths. `this` is neither a reference to the function itself, nor is it a reference to the function's *lexical* scope.
 
 `this` is actually a binding that is made when a function is invoked, and *what* it references is determined entirely by the call-site where the function is called.
+
+#### [Table of Contents](toc.md#table-of-contents) | [Next Chapter ⇒](ch2.md)

--- a/this & object prototypes/ch2.md
+++ b/this & object prototypes/ch2.md
@@ -1,3 +1,5 @@
+#### [⇐ Previous Chapter](ch1.md) | [Table of Contents](toc.md#table-of-contents) | [Next Chapter ⇒](ch3.md)
+
 # You Don't Know JS: *this* & Object Prototypes
 # Chapter 2: `this` All Makes Sense Now!
 
@@ -855,3 +857,5 @@ Determining the `this` binding for an executing function requires finding the di
 Be careful of accidental/unintentional invoking of the *default binding* rule. In cases where you want to "safely" ignore a `this` binding, a "DMZ" object like `ø = Object.create(null)` is a good placeholder value that protects the `global` object from unintended side-effects.
 
 Instead of the four standard binding rules, ES6 arrow-functions use lexical scoping for `this` binding, which means they adopt the `this` binding (whatever it is) from its enclosing function call. They are essentially a syntactic replacement of `self = this` in pre-ES6 coding.
+
+#### [⇐ Previous Chapter](ch1.md) | [Table of Contents](toc.md#table-of-contents) | [Next Chapter ⇒](ch3.md)

--- a/this & object prototypes/ch3.md
+++ b/this & object prototypes/ch3.md
@@ -1,3 +1,5 @@
+#### [⇐ Previous Chapter](ch2.md) | [Table of Contents](toc.md#table-of-contents) | [Next Chapter ⇒](ch4.md)
+
 # You Don't Know JS: *this* & Object Prototypes
 # Chapter 3: Objects
 
@@ -944,3 +946,5 @@ Properties have certain characteristics that can be controlled through property 
 Properties don't have to contain values -- they can be "accessor properties" as well, with getters/setters. They can also be either *enumerable* or not, which controls if they show up in `for..in` loop iterations, for instance.
 
 You can also iterate over **the values** in data structures (arrays, objects, etc) using the ES6 `for..of` syntax, which looks for either a built-in or custom `@@iterator` object consisting of a `next()` method to advance through the data values one at a time.
+
+#### [⇐ Previous Chapter](ch2.md) | [Table of Contents](toc.md#table-of-contents) | [Next Chapter ⇒](ch4.md)

--- a/this & object prototypes/ch4.md
+++ b/this & object prototypes/ch4.md
@@ -1,3 +1,5 @@
+#### [⇐ Previous Chapter](ch3.md) | [Table of Contents](toc.md#table-of-contents) | [Next Chapter ⇒](ch5.md)
+
 # You Don't Know JS: *this* & Object Prototypes
 # Chapter 4: Mixing (Up) "Class" Objects
 
@@ -476,3 +478,5 @@ The mixin pattern (both explicit and implicit) is often used to *sort of* emulat
 Explicit mixins are also not exactly the same as class *copy*, since objects (and functions!) only have shared references duplicated, not the objects/functions duplicated themselves. Not paying attention to such nuance is the source of a variety of gotchas.
 
 In general, faking classes in JS often sets more landmines for future coding than solving present *real* problems.
+
+#### [⇐ Previous Chapter](ch3.md) | [Table of Contents](toc.md#table-of-contents) | [Next Chapter ⇒](ch5.md)

--- a/this & object prototypes/ch5.md
+++ b/this & object prototypes/ch5.md
@@ -1,3 +1,5 @@
+#### [⇐ Previous Chapter](ch4.md) | [Table of Contents](toc.md#table-of-contents) | [Next Chapter ⇒](ch6.md)
+
 # You Don't Know JS: *this* & Object Prototypes
 # Chapter 5: Prototypes
 
@@ -750,3 +752,5 @@ While these JavaScript mechanisms can seem to resemble "class instantiation" and
 For a variety of reasons, not the least of which is terminology precedent, "inheritance" (and "prototypal inheritance") and all the other OO terms just do not make sense when considering how JavaScript *actually* works (not just applied to our forced mental models).
 
 Instead, "delegation" is a more appropriate term, because these relationships are not *copies* but delegation **links**.
+
+#### [⇐ Previous Chapter](ch4.md) | [Table of Contents](toc.md#table-of-contents) | [Next Chapter ⇒](ch6.md)

--- a/this & object prototypes/ch6.md
+++ b/this & object prototypes/ch6.md
@@ -1,3 +1,5 @@
+#### [⇐ Previous Chapter](ch5.md) | [Table of Contents](toc.md#table-of-contents) 
+
 # You Don't Know JS: *this* & Object Prototypes
 # Chapter 6: Behavior Delegation
 
@@ -915,3 +917,5 @@ Behavior delegation suggests objects as peers of each other, which delegate amon
 When you design code with objects only, not only does it simplify the syntax you use, but it can actually lead to simpler code architecture design.
 
 **OLOO** (objects-linked-to-other-objects) is a code style which creates and relates objects directly without the abstraction of classes. OLOO quite naturally implements `[[Prototype]]`-based behavior delegation.
+
+#### [⇐ Previous Chapter](ch5.md) | [Table of Contents](toc.md#table-of-contents) 

--- a/types & grammar/ch1.md
+++ b/types & grammar/ch1.md
@@ -1,3 +1,5 @@
+#### [Table of Contents](toc.md#table-of-contents) | [Next Chapter ⇒](ch2.md)
+
 # You Don't Know JS: Types & Grammar
 # Chapter 1: Types
 
@@ -298,3 +300,5 @@ Many developers will assume "undefined" and "undeclared" are roughly the same th
 JavaScript unfortunately kind of conflates these two terms, not only in its error messages ("ReferenceError: a is not defined") but also in the return values of `typeof`, which is `"undefined"` for both cases.
 
 However, the safety guard (preventing an error) on `typeof` when used against an undeclared variable can be helpful in certain cases.
+
+#### [Table of Contents](toc.md#table-of-contents) | [Next Chapter ⇒](ch2.md)

--- a/types & grammar/ch2.md
+++ b/types & grammar/ch2.md
@@ -1,3 +1,5 @@
+#### [⇐ Previous Chapter](ch1.md) | [Table of Contents](toc.md#table-of-contents) | [Next Chapter ⇒](ch3.md)
+
 # You Don't Know JS: Types & Grammar
 # Chapter 2: Values
 
@@ -983,3 +985,5 @@ The `null` type has just one value: `null`, and likewise the `undefined` type ha
 `number`s include several special values, like `NaN` (supposedly "Not a Number", but really more appropriately "invalid number"); `+Infinity` and `-Infinity`; and `-0`.
 
 Simple scalar primitives (`string`s, `number`s, etc.) are assigned/passed by value-copy, but compound values (`object`s, etc.) are assigned/passed by reference-copy. References are not like references/pointers in other languages -- they're never pointed at other variables/references, only at the underlying values.
+
+#### [⇐ Previous Chapter](ch1.md) | [Table of Contents](toc.md#table-of-contents) | [Next Chapter ⇒](ch3.md)

--- a/types & grammar/ch3.md
+++ b/types & grammar/ch3.md
@@ -1,3 +1,5 @@
+#### [⇐ Previous Chapter](ch2.md) | [Table of Contents](toc.md#table-of-contents) | [Next Chapter ⇒](ch4.md)
+
 # You Don't Know JS: Types & Grammar
 # Chapter 3: Natives
 
@@ -485,3 +487,5 @@ Also, be very careful not to use `Array.prototype` as a default value **that wil
 JavaScript provides object wrappers around primitive values, known as natives (`String`, `Number`, `Boolean`, etc). These object wrappers give the values access to behaviors appropriate for each object subtype (`String#trim()` and `Array#concat(..)`).
 
 If you have a simple scalar primitive value like `"abc"` and you access its `length` property or some `String.prototype` method, JS automatically "boxes" the value (wraps it in its respective object wrapper) so that the property/method accesses can be fulfilled.
+
+#### [⇐ Previous Chapter](ch2.md) | [Table of Contents](toc.md#table-of-contents) | [Next Chapter ⇒](ch4.md)

--- a/types & grammar/ch4.md
+++ b/types & grammar/ch4.md
@@ -1,3 +1,5 @@
+#### [⇐ Previous Chapter](ch3.md) | [Table of Contents](toc.md#table-of-contents) | [Next Chapter ⇒](ch5.md)
+
 # You Don't Know JS: Types & Grammar
 # Chapter 4: Coercion
 
@@ -1917,3 +1919,6 @@ Coercion gets a bad rap, but it's actually quite useful in many cases. An import
 *Implicit* coercion is coercion that is "hidden" as a side-effect of some other operation, where it's not as obvious that the type conversion will occur. While it may seem that *implicit* coercion is the opposite of *explicit* and is thus bad (and indeed, many think so!), actually *implicit* coercion is also about improving the readability of code.
 
 Especially for *implicit*, coercion must be used responsibly and consciously. Know why you're writing the code you're writing, and how it works. Strive to write code that others will easily be able to learn from and understand as well.
+
+
+#### [⇐ Previous Chapter](ch3.md) | [Table of Contents](toc.md#table-of-contents) | [Next Chapter ⇒](ch5.md)

--- a/types & grammar/ch5.md
+++ b/types & grammar/ch5.md
@@ -1,3 +1,5 @@
+#### [⇐ Previous Chapter](ch4.md) | [Table of Contents](toc.md#table-of-contents) 
+
 # You Don't Know JS: Types & Grammar
 # Chapter 5: Grammar
 
@@ -1385,3 +1387,5 @@ Function arguments have an interesting relationship to their formal declared nam
 The `finally` clause attached to a `try` (or `try..catch`) offers some very interesting quirks in terms of execution processing order. Some of these quirks can be helpful, but it's possible to create lots of confusion, especially if combined with labeled blocks. As always, use `finally` to make code better and clearer, not more clever or confusing.
 
 The `switch` offers some nice shorthand for `if..else if..` statements, but beware of many common simplifying assumptions about its behavior. There are several quirks that can trip you up if you're not careful, but there's also some neat hidden tricks that `switch` has up its sleeve!
+
+#### [⇐ Previous Chapter](ch4.md) | [Table of Contents](toc.md#table-of-contents) 

--- a/up & going/ch1.md
+++ b/up & going/ch1.md
@@ -1,3 +1,5 @@
+#### [Table of Contents](toc.md#table-of-contents) | [Next Chapter ⇒](ch2.md)
+
 # You Don't Know JS: Up & Going
 # Chapter 1: Into Programming
 
@@ -800,3 +802,5 @@ Finally, don't neglect the power of practice. The best way to learn how to write
 I'm excited you're well on your way to learning how to code, now! Keep it up. Don't forget to check out other beginner programming resources (books, blogs, online training, etc.). This chapter and this book are a great start, but they're just a brief introduction.
 
 The next chapter will review many of the concepts from this chapter, but from a more JavaScript-specific perspective, which will highlight most of the major topics that are addressed in deeper detail throughout the rest of the series.
+
+#### [Table of Contents](toc.md#table-of-contents) | [Next Chapter ⇒](ch2.md)

--- a/up & going/ch2.md
+++ b/up & going/ch2.md
@@ -1,3 +1,5 @@
+#### [⇐ Previous Chapter](ch1.md) | [Table of Contents](toc.md#table-of-contents) | [Next Chapter ⇒](ch3.md)
+
 # You Don't Know JS: Up & Going
 # Chapter 2: Into JavaScript
 
@@ -960,3 +962,5 @@ The first step to learning JavaScript's flavor of programming is to get a basic 
 Of course, each of these topics deserves much greater coverage than you've seen here, but that's why they have chapters and books dedicated to them throughout the rest of this series. After you feel pretty comfortable with the concepts and code samples in this chapter, the rest of the series awaits you to really dig in and get to know the language deeply.
 
 The final chapter of this book will briefly summarize each of the other titles in the series and the other concepts they cover besides what we've already explored.
+
+#### [⇐ Previous Chapter](ch1.md) | [Table of Contents](toc.md#table-of-contents) | [Next Chapter ⇒](ch3.md)

--- a/up & going/ch3.md
+++ b/up & going/ch3.md
@@ -1,3 +1,5 @@
+#### [⇐ Previous Chapter](ch2.md) | [Table of Contents](toc.md#table-of-contents) 
+
 # You Don't Know JS: Up & Going
 # Chapter 3: Into YDKJS
 
@@ -102,3 +104,5 @@ The *YDKJS* series is dedicated to the proposition that all JS developers can an
 We take each important area of focus in the language and dedicate a short but very dense book to fully explore all the parts of it that you perhaps thought you knew but probably didn't fully.
 
 "You Don't Know JS" isn't a criticism or an insult. It's a realization that all of us, myself included, must come to terms with. Learning JavaScript isn't an end goal but a process. We don't know JavaScript, yet. But we will!
+
+#### [⇐ Previous Chapter](ch2.md) | [Table of Contents](toc.md#table-of-contents) 


### PR DESCRIPTION
It's slightly frustrating to jump from chapter to chapter when reading on GitHub - these links allow you to move back and forth easily from chapter to chapter.