### PR TITLE
fix grammar in "this & object prototypes" chap. 4

### DIFF
--- a/this & object prototypes/ch4.md
+++ b/this & object prototypes/ch4.md
@@ -238,7 +238,7 @@ JavaScript is simpler: it does not provide a native mechanism for "multiple inhe
 
 ## Mixins
 
-JavaScript's object mechanism does not *automatically* perform copy behavior when you "inherit" or "instantiate". Plainly, there's no "classes" in JavaScript to instantiate, only objects. And objects don't get copied to other objects, they get *linked together* (more on that in Chapter 5).
+JavaScript's object mechanism does not *automatically* perform copy behavior when you "inherit" or "instantiate". Plainly, there are no "classes" in JavaScript to instantiate, only objects. And objects don't get copied to other objects, they get *linked together* (more on that in Chapter 5).
 
 Since observed class behaviors in other languages imply copies, let's examine how JS developers **fake** the *missing* copy behavior of classes in JavaScript: mixins. We'll look at two types of "mixin": **explicit** and **implicit**.
 


### PR DESCRIPTION
"classes" is plural, even though it is quoted.

http://www.quickanddirtytips.com/education/grammar/oddness-when-you-start-a-sentence-with-there-is