### PR TITLE
fix(types and gramar - chapter 2)

### DIFF
--- a/types & grammar/ch2.md
+++ b/types & grammar/ch2.md
@@ -446,7 +446,7 @@ To polyfill `Number.isSafeInteger(..)` in pre-ES6 browsers:
 if (!Number.isSafeInteger) {
 	Number.isSafeInteger = function(num) {
 		return Number.isInteger( num ) &&
-			Math.abs( num ) <= Number.MAX_SAFE_INTEGER;
+			Math.abs( num ) < Math.pow(2, 53);
 	};
 }
 ```


### PR DESCRIPTION
- polyfill for `Number.isSafeInteger(..)` in pre-ES6 browsers, is using ES6 only constant: Number.MAX_SAFE_INTEGER
- this fix uses number literal instead