### PR TITLE
Corrected spelling error line 221 in types & grammar/ch2.md

### DIFF
--- a/types & grammar/ch2.md
+++ b/types & grammar/ch2.md
@@ -218,7 +218,7 @@ So, in JS, an "integer" is just a value that has no fractional decimal value. Th
 
 Like most modern languages, including practically all scripting languages, the implementation of JavaScript's `number`s is based on the "IEEE 754" standard, often called "floating-point." JavaScript specifically uses the "double precision" format (aka "64-bit binary") of the standard.
 
-There are many great write-ups on the Web about the nitty-gritty details of how binary floating-point numbers are stored in memory, and the implications of those choices. Because understanding bit patterns in memory is not strictly necessary to understand how to correctly use `number`s in JS, we'll leave it as an excercise for the interested reader if you'd like to dig further into IEEE 754 details.
+There are many great write-ups on the Web about the nitty-gritty details of how binary floating-point numbers are stored in memory, and the implications of those choices. Because understanding bit patterns in memory is not strictly necessary to understand how to correctly use `number`s in JS, we'll leave it as an exercise for the interested reader if you'd like to dig further into IEEE 754 details.
 
 ### Numeric Syntax
 


### PR DESCRIPTION
99.9% sure this is the only way to spell 'exercise' in both the American and British standards of English. 