### PR TITLE
Coerces truthy values to Bool in onlyOne()

### DIFF
--- a/types & grammar/ch4.md
+++ b/types & grammar/ch4.md
@@ -1060,7 +1060,7 @@ function onlyOne() {
 		// skip falsy values. same as treating
 		// them as 0's, but avoids NaN's.
 		if (arguments[i]) {
-			sum += arguments[i];
+			sum += !!arguments[i];
 		}
 	}
 	return sum == 1;


### PR DESCRIPTION
The current version of the implicit coercion form of onlyOne() cannot handle truthy values. For example, onlyOne("42", false) will return false.