### PR TITLE
fix: missing invoke in "Scope & Closures" - ch2.md

### DIFF
--- a/scope & closures/ch5.md
+++ b/scope & closures/ch5.md
@@ -105,6 +105,8 @@ function foo() {
 function bar(fn) {
 	fn(); // look ma, I saw closure!
 }
+
+foo(); // 2
 ```
 
 We pass the inner function `baz` over to `bar`, and call that inner function (labeled `fn` now), and when we do, its closure over the inner scope of `foo()` is observed, by accessing `a`.


### PR DESCRIPTION
I think maybe you should invoke the method `foo()` to make the program execute.