### PR TITLE
Update apA.md

### DIFF
--- a/this & object prototypes/apA.md
+++ b/this & object prototypes/apA.md
@@ -137,7 +137,7 @@ class C {
 		this.id = id;
 	}
 	id() {
-		console.log( "Id: " + id );
+		console.log( "Id: " + this.id );
 	}
 }
 


### PR DESCRIPTION
Looks like a minor ommission.  `id` didn't exist anywhere as a variable.