### PR TITLE
Replace: anti-climatic with anticlimactic

### DIFF
--- a/scope & closures/ch5.md
+++ b/scope & closures/ch5.md
@@ -3,7 +3,7 @@
 
 We arrive at this point with hopefully a very healthy, solid understanding of how scope works.
 
-We turn our attention to an incredibly important, but persistently elusive, *almost mythological*, part of the language: **closure**. If you have followed our discussion of lexical scope thus far, the payoff is that closure is going to be, largely, anti-climatic, almost self-obvious. *There's a man behind the wizard's curtain, and we're about to see him*. No, his name is not Crockford!
+We turn our attention to an incredibly important, but persistently elusive, *almost mythological*, part of the language: **closure**. If you have followed our discussion of lexical scope thus far, the payoff is that closure is going to be, largely, anticlimactic, almost self-obvious. *There's a man behind the wizard's curtain, and we're about to see him*. No, his name is not Crockford!
 
 If however you have nagging questions about lexical scope, now would be a good time to go back and review Chapter 2 before proceeding.
 


### PR DESCRIPTION
Just a simple word swap. Anticlimactic is a word meaning without a climax, whereas climatic will refer to weather/climate. 

P.S. Thanks so damn much for this book series! I love it.