### PR TITLE
Fix missing note

### DIFF
--- a/scope & closures/apB.md
+++ b/scope & closures/apB.md
@@ -120,4 +120,4 @@ The question really becomes: do you want block-scoping, or not. If you do, these
 
 [^note-traceur]: [Google Traceur](http://traceur-compiler.googlecode.com/git/demo/repl.html)
 
-[^note-let_er]: [let-er ](https://github.com/getify/let-er)
+[^note-let_er]\: [let-er](https://github.com/getify/let-er)

--- a/scope & closures/apB.md
+++ b/scope & closures/apB.md
@@ -120,4 +120,4 @@ The question really becomes: do you want block-scoping, or not. If you do, these
 
 [^note-traceur]: [Google Traceur](http://traceur-compiler.googlecode.com/git/demo/repl.html)
 
-[^note-let_er]: [let-er](https://github.com/getify/let-er)
+[^note-let_er]: [let-er ](https://github.com/getify/let-er)


### PR DESCRIPTION
[^note-let_er]: [let-er] will not display anything as a space is required after the text 'let-er'. I have added this space and the note now appears at the bottom of the page.