### PR TITLE
I suggest the following edit on line 455

### DIFF
--- a/async & performance/ch3.md
+++ b/async & performance/ch3.md
@@ -452,7 +452,7 @@ Promises by definition cannot be susceptible to this concern, because even an im
 
 That is, when you call `then(..)` on a Promise, even if that Promise was already resolved, the callback you provide to `then(..)` will **always** be called asynchronously (for more on this, refer back to "Jobs" in Chapter 1).
 
-No more need to insert your own `setTimeout(..,0)` hacks. Promises prevent Zalgo automatically.
+No more need to insert your own `setTimeout(.., 0)` hacks. Promises prevent Zalgo automatically.
 
 ### Calling Too Late
 


### PR DESCRIPTION
Because all other `setTimeout( )` functions in this chapter contain a space after the comma between parameters (528 - 530, 836 - 839, 857, 1107 - 1109, 1127 - 1135, 1727 - 1729), I suggest the following edit on line 455:

`setTimeout(..,0)` --> `setTimeout(.., 0)`