### PR TITLE
Unnecessary parentheses

### DIFF
--- a/scope & closures/ch3.md
+++ b/scope & closures/ch3.md
@@ -91,7 +91,7 @@ function doSomething(a) {
 
 	b = a + doSomethingElse( a * 2 );
 
-	console.log( (b * 3) );
+	console.log( b * 3 );
 }
 
 doSomething( 2 ); // 15


### PR DESCRIPTION
I can't see any reason for the extra pair of parentheses being there