### PR TITLE
Fix expected result

### DIFF
--- a/scope & closures/ch4.md
+++ b/scope & closures/ch4.md
@@ -158,7 +158,7 @@ foo = function() {
 };
 ```
 
-`1` is printed instead of `2`! This snippet is interpreted by the *Engine* as:
+`1` is printed instead of a TypeError ! This snippet is interpreted by the *Engine* as:
 
 ```js
 function foo() {


### PR DESCRIPTION
In [chapter 4 "Hoisting" of "Scope & Closures"](https://github.com/getify/You-Dont-Know-JS/blob/master/scope%20&%20closures/ch4.md#functions-first), we want to demonstrate that functions are hoisted before variables. The snippet uses a function declaration, logging `1` in console, and a function expression, logging `2`, and say "1 is printed instead of 2" (despites that the function declaration appears before the function expression).

The previous paragraph demonstrates that function expressions are not hoisted.

````js
foo(); // Uncaught TypeError: foo is not a function(…)

var foo;

foo = function() {
    console.log( 2 );
};
```