### PR TITLE
Typos with effect / affecting

### DIFF
--- a/types & grammar/ch5.md
+++ b/types & grammar/ch5.md
@@ -139,7 +139,7 @@ var a = 1;
 foo();		// result: `undefined`, side effect: changed `a`
 ```
 
-There are other side-effecting expressions, though. For example:
+There are other side-affecting expressions, though. For example:
 
 ```js
 var a = 42;
@@ -172,7 +172,7 @@ a;		// 44
 
 When `++` is used in the prefix position as `++a`, its side effect (incrementing `a`) happens *before* the value is returned from the expression, rather than *after* as with `a++`.
 
-**Note:** Would you think `++a++` was legal syntax? If you try it, you'll get a `ReferenceError` error, but why? Because side-effecting operators **require a variable reference** to target their side effects to. For `++a++`, the `a++` part is evaluated first (because of operator precedence -- see below), which gives back the value of `a` _before_ the increment. But then it tries to evaluate `++42`, which (if you try it) gives the same `ReferenceError` error, since `++` can't have a side effect directly on a value like `42`.
+**Note:** Would you think `++a++` was legal syntax? If you try it, you'll get a `ReferenceError` error, but why? Because side-affecting operators **require a variable reference** to target their side effects to. For `++a++`, the `a++` part is evaluated first (because of operator precedence -- see below), which gives back the value of `a` _before_ the increment. But then it tries to evaluate `++42`, which (if you try it) gives the same `ReferenceError` error, since `++` can't have a side effect directly on a value like `42`.
 
 It is sometimes mistakenly thought that you can encapsulate the *after* side effect of `a++` by wrapping it in a `( )` pair, like:
 
@@ -200,7 +200,7 @@ b;	// 43
 
 The expression `a++, a` means that the second `a` statement expression gets evaluated *after* the *after side effects* of the first `a++` statement expression, which means it returns the `43` value for assignment to `b`.
 
-Another example of a side-effecting operator is `delete`. As we showed in Chapter 2, `delete` is used to remove a property from an `object` or a slot from an `array`. But it's usually just called as a standalone statement:
+Another example of a side-affecting operator is `delete`. As we showed in Chapter 2, `delete` is used to remove a property from an `object` or a slot from an `array`. But it's usually just called as a standalone statement:
 
 ```js
 var obj = {
@@ -216,7 +216,7 @@ The result value of the `delete` operator is `true` if the requested operation i
 
 **Note:** What do we mean by valid/allowable? Nonexistent properties, or properties that exist and are configurable (see Chapter 3 of the *this & Object Prototypes* title of this series) will return `true` from the `delete` operator. Otherwise, the result will be `false` or an error.
 
-One last example of a side-effecting operator, which may at once be both obvious and nonobvious, is the `=` assignment operator.
+One last example of a side-affecting operator, which may at once be both obvious and nonobvious, is the `=` assignment operator.
 
 Consider:
 
@@ -227,7 +227,7 @@ a = 42;		// 42
 a;			// 42
 ```
 
-It may not seem like `=` in `a = 42` is a side-effecting operator for the expression. But if we examine the result value of the `a = 42` statement, it's the value that was just assigned (`42`), so the assignment of that same value into `a` is essentially a side effect.
+It may not seem like `=` in `a = 42` is a side-affecting operator for the expression. But if we examine the result value of the `a = 42` statement, it's the value that was just assigned (`42`), so the assignment of that same value into `a` is essentially a side effect.
 
 **Tip:** The same reasoning about side effects goes for the compound-assignment operators like `+=`, `-=`, etc. For example, `a = b += 2` is processed first as `b += 2` (which is `b = b + 2`), and the result of *that* `=` assignment is then assigned to `a`.
 


### PR DESCRIPTION
EDIT: This is in Types and Grammar Chp 5, notably this section: 
https://github.com/getify/You-Dont-Know-JS/blob/master/types%20%26%20grammar/ch5.md#expression-side-effects

I notice you refer to operators with side effects a lot, and use the verb `side-effecting` while I can understand that it would be logical to simply add `ing` to the end of `side-effect`, that verb is used differently. Technically, you should be using `affecting` instead. However, one could make the case that using the term `side-effecting` makes it clearer for the readers to understand that it is simply a reference to operators with side-effects, which are defined beforehand. It's up to you to decide, though I submitted the orthographically correct changes in this commit in case you want to correct it.