### PR TITLE
fix typo

### DIFF
--- a/types & grammar/ch2.md
+++ b/types & grammar/ch2.md
@@ -574,7 +574,7 @@ The `number` type includes several special values. We'll take a look at each in 
 
 #### The Not Number, Number
 
-Any mathematic operation you perform without both operands being `number`s (or values that can be interpreted as regular `number`s in base 10 or base 16) will result in the operation failing to produce a valid `number`, in which case you will get the `NaN` value.
+Any mathematical operation you perform without both operands being `number`s (or values that can be interpreted as regular `number`s in base 10 or base 16) will result in the operation failing to produce a valid `number`, in which case you will get the `NaN` value.
 
 `NaN` literally stands for "not a `number`", though this label/description is very poor and misleading, as we'll see shortly. It would be much more accurate to think of `NaN` as being "invalid number," "failed number," or even "bad number," than to think of it as "not a number."
 


### PR DESCRIPTION
added "al" to "mathematic" in the expression "Any mathematic operation".