### PR TITLE
Fixing Example for CH4 Types And Grammar - Abstract Relational Comparison

### DIFF
--- a/types & grammar/ch4.md
+++ b/types & grammar/ch4.md
@@ -1830,8 +1830,8 @@ The algorithm first calls `ToPrimitive` coercion on both values, and if the retu
 For example:
 
 ```js
-var a = [ 42 ];
-var b = [ "43" ];
+var a = { valueOf:function() {return 42;} };
+var b = [ "143" ];
 
 a < b;	// true
 b < a;	// false


### PR DESCRIPTION
There are two issues with the following example:

> _The algorithm first calls ToPrimitive coercion on both values, and if the return result of either call is not a string, then both values are coerced to number values using the ToNumber operation rules, and compared numerically._
```javascript
var a = [ 42 ];
var b = [ "43" ];
 a < b; // true
 b < a; // false
```

First of all, comparison will yield exact same value when you compare numerical and string values, so:
```
"42" < "43"; // true
42 < 43; // true
```

Which masks the second problem: In this case both of`[ 42 ]` and `[ "43" ]` they will become strings after ToPrimitive.

In order to solve both of this problems this PR changes `b` value to `["143"]`, which will cause string comparison to yield different value than text comparison.
Change made to `a` value is to make sure ToPrimitive function for it will return number.