### PR TITLE
Use strict-equals rather than loose-equals in example

### DIFF
--- a/up & going/ch1.md
+++ b/up & going/ch1.md
@@ -199,7 +199,7 @@ Here are some of the most common operators in JavaScript:
 * Object Property Access: `.` as in `console.log()`.
 
    Objects are values that hold other values at specific named locations called properties. `obj.a` means an object value called `obj` with a property of the name `a`. Properties can alternatively be accessed as `obj["a"]`. See Chapter 2.
-* Equality: `==` (loose-equals), `===` (strict-equals), `!=` (loose not-equals), `!==` (strict not-equals), as in `a == b`.
+* Equality: `==` (loose-equals), `===` (strict-equals), `!=` (loose not-equals), `!==` (strict not-equals), as in `a === b`.
 
    See "Values & Types" and Chapter 2.
 * Comparison: `<` (less than), `>` (greater than), `<=` (less than or loose-equals), `>=` (greater than or loose-equals), as in `a <= b`.


### PR DESCRIPTION
Would be great to let beginners befriend `===` rather than `==` upon their first encounter with the equality operators.