### PR TITLE
"types & grammar" ch 4: Add js syntax highlighting

### DIFF
--- a/types & grammar/ch4.md
+++ b/types & grammar/ch4.md
@@ -1002,7 +1002,7 @@ Generally, this sort of gotcha won't bite you unless you're really trying to cre
 
 What about the other direction? How can we *implicitly coerce* from `string` to `number`?
 
-```
+```js
 var a = "3.14";
 var b = a - 0;
 


### PR DESCRIPTION
JS syntax highlighting was missing in the snippet: 

```
var a = "3.14";
var b = a - 0;

b; // 3.14
```