### PR TITLE
Easily movable table of contents to up&going

### DIFF
--- a/up & going/ch1.md
+++ b/up & going/ch1.md
@@ -13,6 +13,19 @@ Once you feel comfortable with general programming basics, Chapter 2 will help g
 
 If you're already fairly comfortable with JavaScript, first check out Chapter 3 as a brief glimpse of what to expect from *YDKJS*, then jump right in!
 
+* Chapter 1: Into Programming
+	* [Code](https://github.com/uppusaikiran/You-Dont-Know-JS/blob/master/up%20&%20going/ch1.md#code)
+	* [Try It Yourself](https://github.com/uppusaikiran/You-Dont-Know-JS/blob/master/up%20&%20going/ch1.md#try-it-yourself)
+	* [Operators](https://github.com/uppusaikiran/You-Dont-Know-JS/blob/master/up%20&%20going/ch1.md#operators)
+	* [Values & Types](https://github.com/uppusaikiran/You-Dont-Know-JS/blob/master/up%20&%20going/ch1.md#values--types)
+	* [Code Comments](https://github.com/uppusaikiran/You-Dont-Know-JS/blob/master/up%20&%20going/ch1.md#code-comments)
+	* [Variables](https://github.com/uppusaikiran/You-Dont-Know-JS/blob/master/up%20&%20going/ch1.md#variables)
+	* [Blocks](https://github.com/uppusaikiran/You-Dont-Know-JS/blob/master/up%20&%20going/ch1.md#blocks)
+	* [Conditionals](https://github.com/uppusaikiran/You-Dont-Know-JS/blob/master/up%20&%20going/ch1.md#conditionals)
+	* [Loops](https://github.com/uppusaikiran/You-Dont-Know-JS/blob/master/up%20&%20going/ch1.md#loops)
+	* [Functions](https://github.com/uppusaikiran/You-Dont-Know-JS/blob/master/up%20&%20going/ch1.md#functions)
+	* [Practice](https://github.com/uppusaikiran/You-Dont-Know-JS/blob/master/up%20&%20going/ch1.md#practice)
+
 ## Code
 
 Let's start from the beginning.

--- a/up & going/ch1.md
+++ b/up & going/ch1.md
@@ -13,18 +13,19 @@ Once you feel comfortable with general programming basics, Chapter 2 will help g
 
 If you're already fairly comfortable with JavaScript, first check out Chapter 3 as a brief glimpse of what to expect from *YDKJS*, then jump right in!
 
-* Chapter 1: Into Programming
-	* [Code](https://github.com/uppusaikiran/You-Dont-Know-JS/blob/master/up%20&%20going/ch1.md#code)
-	* [Try It Yourself](https://github.com/uppusaikiran/You-Dont-Know-JS/blob/master/up%20&%20going/ch1.md#try-it-yourself)
-	* [Operators](https://github.com/uppusaikiran/You-Dont-Know-JS/blob/master/up%20&%20going/ch1.md#operators)
-	* [Values & Types](https://github.com/uppusaikiran/You-Dont-Know-JS/blob/master/up%20&%20going/ch1.md#values--types)
-	* [Code Comments](https://github.com/uppusaikiran/You-Dont-Know-JS/blob/master/up%20&%20going/ch1.md#code-comments)
-	* [Variables](https://github.com/uppusaikiran/You-Dont-Know-JS/blob/master/up%20&%20going/ch1.md#variables)
-	* [Blocks](https://github.com/uppusaikiran/You-Dont-Know-JS/blob/master/up%20&%20going/ch1.md#blocks)
-	* [Conditionals](https://github.com/uppusaikiran/You-Dont-Know-JS/blob/master/up%20&%20going/ch1.md#conditionals)
-	* [Loops](https://github.com/uppusaikiran/You-Dont-Know-JS/blob/master/up%20&%20going/ch1.md#loops)
-	* [Functions](https://github.com/uppusaikiran/You-Dont-Know-JS/blob/master/up%20&%20going/ch1.md#functions)
-	* [Practice](https://github.com/uppusaikiran/You-Dont-Know-JS/blob/master/up%20&%20going/ch1.md#practice)
+### Table of contents
+
+* [Code](https://github.com/uppusaikiran/You-Dont-Know-JS/blob/master/up%20&%20going/ch1.md#code)
+* [Try It Yourself](https://github.com/uppusaikiran/You-Dont-Know-JS/blob/master/up%20&%20going/ch1.md#try-it-yourself)
+* [Operators](https://github.com/uppusaikiran/You-Dont-Know-JS/blob/master/up%20&%20going/ch1.md#operators)
+* [Values & Types](https://github.com/uppusaikiran/You-Dont-Know-JS/blob/master/up%20&%20going/ch1.md#values--types)
+* [Code Comments](https://github.com/uppusaikiran/You-Dont-Know-JS/blob/master/up%20&%20going/ch1.md#code-comments)
+* [Variables](https://github.com/uppusaikiran/You-Dont-Know-JS/blob/master/up%20&%20going/ch1.md#variables)
+* [Blocks](https://github.com/uppusaikiran/You-Dont-Know-JS/blob/master/up%20&%20going/ch1.md#blocks)
+* [Conditionals](https://github.com/uppusaikiran/You-Dont-Know-JS/blob/master/up%20&%20going/ch1.md#conditionals)
+* [Loops](https://github.com/uppusaikiran/You-Dont-Know-JS/blob/master/up%20&%20going/ch1.md#loops)
+* [Functions](https://github.com/uppusaikiran/You-Dont-Know-JS/blob/master/up%20&%20going/ch1.md#functions)
+* [Practice](https://github.com/uppusaikiran/You-Dont-Know-JS/blob/master/up%20&%20going/ch1.md#practice)
 
 ## Code
 

--- a/up & going/ch2.md
+++ b/up & going/ch2.md
@@ -11,6 +11,19 @@ Your journey to deeply learn JavaScript starts here.
 
 **Note:** As I said in Chapter 1, you should definitely try all this code yourself as you read and work through this chapter. Be aware that some of the code here assumes capabilities introduced in the newest version of JavaScript at the time of this writing (commonly referred to as "ES6" for the 6th edition of ECMAScript -- the official name of the JS specification). If you happen to be using an older, pre-ES6 browser, the code may not work. A recent update of a modern browser (like Chrome, Firefox, or IE) should be used.
 
+### Table of contents
+
+* [Values & Types](https://github.com/uppusaikiran/You-Dont-Know-JS/blob/master/up%20%26%20going/ch2.md#values--types)
+* [Variables](https://github.com/uppusaikiran/You-Dont-Know-JS/blob/master/up%20%26%20going/ch2.md#variables)
+* [Conditionals](https://github.com/uppusaikiran/You-Dont-Know-JS/blob/master/up%20%26%20going/ch2.md#conditionals)
+* [Strict Mode](https://github.com/uppusaikiran/You-Dont-Know-JS/blob/master/up%20%26%20going/ch2.md#strict-mode)
+* [Functions As Values](https://github.com/uppusaikiran/You-Dont-Know-JS/blob/master/up%20%26%20going/ch2.md#functions-as-values)
+* [`this` Keyword](https://github.com/uppusaikiran/You-Dont-Know-JS/blob/master/up%20%26%20going/ch2.md#this-identifier)
+* [Prototypes](https://github.com/uppusaikiran/You-Dont-Know-JS/blob/master/up%20%26%20going/ch2.md#prototypes)
+* [Old & New](https://github.com/uppusaikiran/You-Dont-Know-JS/blob/master/up%20%26%20going/ch2.md#old--new)
+* [Non-JavaScript](https://github.com/uppusaikiran/You-Dont-Know-JS/blob/master/up%20%26%20going/ch2.md#non-javascript)
+
+
 ## Values & Types
 
 As we asserted in Chapter 1, JavaScript has typed values, not typed variables. The following built-in types are available:

--- a/up & going/ch3.md
+++ b/up & going/ch3.md
@@ -9,6 +9,14 @@ The *You Don't Know JS* (*YDKJS*) series stands in stark contrast to the typical
 
 I'm going to use this final chapter to briefly summarize what to expect from the rest of the books in the series, and how to most effectively go about building a foundation of JS learning on top of *YDKJS*.
 
+### Table of contents
+
+* [Scope & Closures](https://github.com/uppusaikiran/You-Dont-Know-JS/blob/master/up%20%26%20going/ch3.md#scope--closures)
+* [this & Object Prototypes](https://github.com/uppusaikiran/You-Dont-Know-JS/blob/master/up%20%26%20going/ch3.md#this--object-prototypes)
+* [Types & Grammar](https://github.com/uppusaikiran/You-Dont-Know-JS/blob/master/up%20%26%20going/ch3.md#types--grammar)
+* [Async & Performance](https://github.com/uppusaikiran/You-Dont-Know-JS/blob/master/up%20%26%20going/ch3.md#async--performance)
+* [ES6 & Beyond](https://github.com/uppusaikiran/You-Dont-Know-JS/blob/master/up%20%26%20going/ch3.md#es6--beyond)
+
 ## Scope & Closures
 
 Perhaps one of the most fundamental things you'll need to quickly come to terms with is how scoping of variables really works in JavaScript. It's not enough to have anecdotal fuzzy *beliefs* about scope.


### PR DESCRIPTION
When i was going to readme.md file,because it is so large i often lost where iam presently there.So entire chapter into several sub modules and these sub modules are listed as table of contents and links to appropriate sub modules are added.