### PR TITLE
Update link for Traceur

### DIFF
--- a/scope & closures/apB.md
+++ b/scope & closures/apB.md
@@ -118,6 +118,6 @@ Secondly, IIFE is not a fair apples-to-apples comparison with `try/catch`, becau
 
 The question really becomes: do you want block-scoping, or not. If you do, these tools provide you that option. If not, keep using `var` and go on about your coding!
 
-[^note-traceur]: [Google Traceur](http://traceur-compiler.googlecode.com/git/demo/repl.html)
+[^note-traceur]: [Google Traceur](https://github.com/google/traceur-compiler)
 
 [^note-let_er]\: [let-er](https://github.com/getify/let-er)


### PR DESCRIPTION
The Traceur repository is now hosted on GitHub. The original link to a site on Google Code is not valid anymore because the hosting service ended, which was announced at http://google-opensource.blogspot.com/2015/03/farewell-to-google-code.html
