### PR TITLE
es6+beyond: ch2.md, fixing word order issue

### DIFF
--- a/es6 & beyond/ch2.md
+++ b/es6 & beyond/ch2.md
@@ -2533,7 +2533,7 @@ var s1 = "abc\u0301d",
 [...s3.normalize()][2];			// "𝒞"
 ```
 
-**Warning:** Reminder of an earlier warning: constructing and exhausting an iterator each time you want to get at a single character is... very not ideal, performance wise. Let's hope we get a built-in and optimized utility for this soon, post-ES6.
+**Warning:** Reminder of an earlier warning: constructing and exhausting an iterator each time you want to get at a single character is... not very ideal, performance wise. Let's hope we get a built-in and optimized utility for this soon, post-ES6.
 
 What about a Unicode-aware version of the `charCodeAt(..)` utility? ES6 gives us `codePointAt(..)`:
 


### PR DESCRIPTION
Small word order change.  Original text:
"is... very not ideal, performance wise."
![screen shot 2016-07-24 at 8 33 52 pm](https://cloud.githubusercontent.com/assets/16548994/17088411/24a5adbe-51e0-11e6-859d-cb8d3c56b0da.png)

Changed to read:
"is... not very ideal, performance wise."
![screen shot 2016-07-24 at 8 51 23 pm](https://cloud.githubusercontent.com/assets/16548994/17088459/d20ba698-51e0-11e6-8689-a03c19080213.png)
