### PR TITLE
es6+beyond: ch3.md, fixing typo

### DIFF
--- a/es6 & beyond/ch3.md
+++ b/es6 & beyond/ch3.md
@@ -843,7 +843,7 @@ it.return( 42 );		// cleanup!
 						// { value: 42, done: true }
 ```
 
-**Warning:** Do not put a `yield` statement inside the `finally` clause! It's valid and legal, but it's a really terrible idea. It acts in a sense as deferring the completion of the `return(..)` call you made, as any `yield ..` expressions in the `finally` clause are respected to pause and send messages; you don't immediately get a completed generator as expected. There's basically no good reason to opt in to that crazy *bad part*, so avoid doing so!
+**Warning:** Do not put a `yield` statement inside the `finally` clause! It's valid and legal, but it's a really terrible idea. It acts in a sense as deferring the completion of the `return(..)` call you made, as any `yield ..` expressions in the `finally` clause are expected to pause and send messages; you don't immediately get a completed generator as expected. There's basically no good reason to opt in to that crazy *bad part*, so avoid doing so!
 
 In addition to the previous snippet showing how `return(..)` aborts the generator while still triggering the `finally` clause, it also demonstrates that a generator produces a whole new iterator each time it's called. In fact, you can use multiple iterators attached to the same generator concurrently:
 


### PR DESCRIPTION
Update to the wording in es6 & beyond: ch3.  If this was your intended meaning, I hope it helps :)
Previous wording:
"as any `yield ..` expressions in the `finally` clause are respected to pause and send messages"
![screen shot 2016-07-25 at 8 23 17 am](https://cloud.githubusercontent.com/assets/16548994/17103155/9a41062e-5242-11e6-9078-498ba3714b39.png)

Intended wording:
"as any `yield ..` expressions in the `finally` clause are expected to pause and send messages"

![screen shot 2016-07-25 at 8 32 24 am](https://cloud.githubusercontent.com/assets/16548994/17103166/a617a75a-5242-11e6-82cb-f56c82dc74c2.png)