### PR TITLE
Error in example.md

### DIFF
--- a/types & grammar/ch4.md
+++ b/types & grammar/ch4.md
@@ -1830,8 +1830,8 @@ The algorithm first calls `ToPrimitive` coercion on both values, and if the retu
 For example:
 
 ```js
-var a = [ 42 ];
-var b = [ "43" ];
+var a = new Number(42);
+var b = [ "043" ];
 
 a < b;	// true
 b < a;	// false


### PR DESCRIPTION
On of the two values must have not a 'string' as the result of the 'ToPrimitive' coersion. 

When ToPrimitive is called on an array, the result will always be a string, because the valueOf is returning the array itself. When this method isn't returning a primitive value, it will try using toString().