### PR TITLE
corrected error in hoisting example

### DIFF
--- a/scope & closures/ch4.md
+++ b/scope & closures/ch4.md
@@ -158,7 +158,7 @@ foo = function() {
 };
 ```
 
-`1` is printed instead of `2`! This snippet is interpreted by the *Engine* as:
+`1` is printed instead of a `TypeError` from trying to invoke `undefined`, which is not a function! This snippet is interpreted by the *Engine* as:
 
 ```js
 function foo() {


### PR DESCRIPTION
if the variable declaration is hoisted first, the function declaration is treated as a duplicate and thus ignored. At the point of invoking `foo()`, the value of `foo` is `undefined` and therefore should throw a `TypeError`.