### PR TITLE
Ch4:Change log statement and remove //yep comment.

### DIFF
--- a/types & grammar/ch4.md
+++ b/types & grammar/ch4.md
@@ -1138,7 +1138,7 @@ c = d ? a : b;
 c;								// "abc"
 
 if ((a && d) || c) {
-	console.log( "yep" );		// yep
+	console.log( "nope, not going to run as undefined is falsy." );
 }
 ```
 


### PR DESCRIPTION
As it currently reads it seems to indicate to the reader that the if block will execute. It wouldn't.

As i read it, a && d is 42 && null which results in null.
then d || c is null || undefined which results in undefined.

undefined is falsy so the console statement will not execute.