### PR TITLE
Make a letter uppercase to match list style

### DIFF
--- a/async & performance/ch3.md
+++ b/async & performance/ch3.md
@@ -440,7 +440,7 @@ Let's start by reviewing the trust issues with callbacks-only coding. When you p
 * Call the callback too late (or never)
 * Call the callback too few or too many times
 * Fail to pass along any necessary environment/parameters
-* swallow any errors/exceptions that may happen
+* Swallow any errors/exceptions that may happen
 
 The characteristics of Promises are intentionally designed to provide useful, repeatable answers to all these concerns.
 


### PR DESCRIPTION
"swallow" had inconsistent casing from its list, so this fixes that error.