### PR TITLE
No need for  [Symbol.iterator]() { return this; }, here ?

### DIFF
--- a/es6 & beyond/ch3.md
+++ b/es6 & beyond/ch3.md
@@ -194,9 +194,6 @@ var Fib = {
 		var n1 = 1, n2 = 1;
 
 		return {
-			// make the iterator an iterable
-			[Symbol.iterator]() { return this; },
-
 			next() {
 				var current = n2;
 				n2 = n1;


### PR DESCRIPTION
I don't understand why we should make the the Fib iterator an iterable here since Fib is already an iterable ? It's more confusing than anything IMO.
