### PR TITLE
foo() returns "a"

### DIFF
--- a/scope & closures/ch4.md
+++ b/scope & closures/ch4.md
@@ -197,7 +197,7 @@ While this all may sound like nothing more than interesting academic trivia, it 
 Function declarations that appear inside of normal blocks typically hoist to the enclosing scope, rather than being conditional as this code implies:
 
 ```js
-foo(); // "b"
+foo(); // "a"
 
 var a = true;
 if (a) {


### PR DESCRIPTION
**I'm not sure about this,** but we have this code:
```
foo(); // "b"

var a = true;
if (a) {
   function foo() { console.log( "a" ); }
}
else {
   function foo() { console.log( "b" ); }
}
```

and `foo()` returns` "a"`, but in the comment after` foo()` we have:

`foo(); // "b"`

But the function `foo()` returns `"a"`


