### PR TITLE
Keep up to date with ES spec "types & grammar" ch1.mod

### DIFF
--- a/types & grammar/ch1.md
+++ b/types & grammar/ch1.md
@@ -1,11 +1,11 @@
 # You Don't Know JS: Types & Grammar
 # Chapter 1: Types
 
-Most developers would say that a dynamic language (like JS) does not have *types*. Let's see what the ES5.1 specification (http://www.ecma-international.org/ecma-262/5.1/) has to say on the topic:
+Most developers would say that a dynamic language (like JS) does not have *types*. Let's see what the ES7.0 specification (http://www.ecma-international.org/ecma-262/7.0/) has to say on the topic:
 
 > Algorithms within this specification manipulate values each of which has an associated type. The possible value types are exactly those defined in this clause. Types are further sub classified into ECMAScript language types and specification types.
 >
-> An ECMAScript language type corresponds to values that are directly manipulated by an ECMAScript programmer using the ECMAScript language. The ECMAScript language types are Undefined, Null, Boolean, String, Number, and Object.
+> An ECMAScript language type corresponds to values that are directly manipulated by an ECMAScript programmer using the ECMAScript language. The ECMAScript language types are Undefined, Null, Boolean, String, Symbol, Number, and Object. An ECMAScript language value is a value that is characterized by an ECMAScript language type.
 
 Now, if you're a fan of strongly typed (statically typed) languages, you may object to this usage of the word "type." In those languages, "type" means a whole lot *more* than it does here in JS.
 


### PR DESCRIPTION
The ECMAScript language types quotation is missing Symbol Type. I have updated quotation from Ecma-262 Edition 5.1 to 7.0 and updated the link
