### PR TITLE
Error : Up & Going(Ch2) - Removes the var keyword

### DIFF
--- a/up & going/ch2.md
+++ b/up & going/ch2.md
@@ -780,7 +780,7 @@ function foo() {
 	console.log( this.bar );
 }
 
-var bar = "global";
+bar = "global";
 
 var obj1 = {
 	bar: "obj1",


### PR DESCRIPTION
With the `var` keyword while calling the `foo` function output is `undefined`. Only when the `var` keyword is not used `bar` will be declared as a property of the global object thus giving `global` as the output when the function `foo` is called.