### PR TITLE
add the function type to typeof examples

### DIFF
--- a/up & going/ch2.md
+++ b/up & going/ch2.md
@@ -20,6 +20,7 @@ As we asserted in Chapter 1, JavaScript has typed values, not typed variables. T
 * `boolean`
 * `null` and `undefined`
 * `object`
+* `function`
 * `symbol` (new to ES6)
 
 JavaScript provides a `typeof` operator that can examine a value and tell you what type it is:
@@ -45,6 +46,11 @@ typeof a;				// "undefined"
 
 a = { b: "c" };
 typeof a;				// "object"
+
+a = function () {
+    console.log("hello world");
+};
+typeof a;				// "function"
 ```
 
 The return value from the `typeof` operator is always one of six (seven as of ES6! - the "symbol" type) string values. That is, `typeof "abc"` returns `"string"`, not `string`.

--- a/up & going/ch2.md
+++ b/up & going/ch2.md
@@ -20,10 +20,9 @@ As we asserted in Chapter 1, JavaScript has typed values, not typed variables. T
 * `boolean`
 * `null` and `undefined`
 * `object`
-* `function`
 * `symbol` (new to ES6)
 
-JavaScript provides a `typeof` operator that can examine a value and tell you what type it is:
+JavaScript provides a `typeof` operator that can examine a value and tell you what type it is, some of its outputs are illustrated here:
 
 ```js
 var a;
@@ -46,11 +45,6 @@ typeof a;				// "undefined"
 
 a = { b: "c" };
 typeof a;				// "object"
-
-a = function () {
-    console.log("hello world");
-};
-typeof a;				// "function"
 ```
 
 The return value from the `typeof` operator is always one of six (seven as of ES6! - the "symbol" type) string values. That is, `typeof "abc"` returns `"string"`, not `string`.


### PR DESCRIPTION
(not addressing the symbol type), the text mentions six possible values for typeof, but the code example and introduction code only states five of them. adding the function type to align with the text.
