### PR TITLE
Wrong Result

### DIFF
--- a/types & grammar/ch4.md
+++ b/types & grammar/ch4.md
@@ -1137,7 +1137,7 @@ while (c) {
 c = d ? a : b;
 c;								// "abc"
 
-if ((a && d) || c) {
+if (!(a && d) || c) {
 	console.log( "yep" );		// yep
 }
 ```


### PR DESCRIPTION
The boolean coercion of previous code `((a && d) || c)` is `false` , the the statement.  I  added `!` it will be `true` and the statement will run correctly.