### PR TITLE
Ch2: Object Property Assignment Pattern mistake

### DIFF
--- a/es6 & beyond/ch2.md
+++ b/es6 & beyond/ch2.md
@@ -595,7 +595,7 @@ console.log( x, y, z );				// 4 5 6
 
 Pretty cool, right?
 
-But is `{ x, .. }` leaving off the `x: ` part or leaving off the `: x` part? We're actually leaving off the `x: ` part when we use the shorter syntax. That may not seem like an important detail, but you'll understand its importance in just a moment.
+But is `{ x, .. }` leaving off the `x: ` part or leaving off the `: x` part? We're actually leaving off the `: x` part when we use the shorter syntax. That may not seem like an important detail, but you'll understand its importance in just a moment.
 
 If you can write the shorter form, why would you ever write out the longer form? Because that longer form actually allows you to assign a property to a different variable name, which can sometimes be quite useful:
 


### PR DESCRIPTION
> But is `{ x, .. }` leaving off the `x: ` part or leaving off the `: x` part? We're actually leaving off the `x: `

In my opinion we are leaving off the `: x` part.
Am I right?

```
function bar() {
    return {
        x: 4,
        y: 5,
        z: 6
    };
}

var { bam, baz, bap } = bar();

console.log( bam, baz, bap );        // undefined undefined undefined
```