### PR TITLE
Typo

### DIFF
--- a/this & object prototypes/ch4.md
+++ b/this & object prototypes/ch4.md
@@ -31,7 +31,7 @@ While `Vehicle` and `Car` collectively define the behavior by way of methods, th
 
 **And thus, classes, inheritance, and instantiation emerge.**
 
-Another key concept with classes is "polymorphism", which describes the idea that a general behavior from a parent class can be overridden in a child class to give it more specifics. In fact, relative polymorphism lets us reference the base behavior from the overridden behavior.
+Another key concept with classes is "polymorphism", which describes the idea that a general behavior from a parent class can be overridden in a child class to give it more specifics. In fact, relative polymorphism lets us reference the base behavior from the overridden behavior ( In this sentence, aren't the `base behavior` and the `overridden behavior` the same? What I think it should be: `In fact, relative polymorphism lets us reference the base behavior from the overriding behavior.` ) .
 
 Class theory strongly suggests that a parent class and a child class share the same method name for a certain behavior, so that the child overrides the parent (differentially). As we'll see later, doing so in your JavaScript code is opting into frustration and code brittleness.
 


### PR DESCRIPTION
**In fact, relative polymorphism lets us reference the base behavior from the overridden behavior.** ( In this sentence, aren't the `base behavior` and the `overridden behavior` the same? What I think it should be: `In fact, relative polymorphism lets us reference the base behavior from the overriding behavior.` )