### PR TITLE
Correct command output

### DIFF
--- a/scope & closures/ch4.md
+++ b/scope & closures/ch4.md
@@ -197,7 +197,7 @@ While this all may sound like nothing more than interesting academic trivia, it 
 Function declarations that appear inside of normal blocks typically hoist to the enclosing scope, rather than being conditional as this code implies:
 
 ```js
-foo(); // "b"
+foo(); // "a"
 
 var a = true;
 if (a) {


### PR DESCRIPTION
The code outputs "a" instead of "b" when executed.