### PR TITLE
Add cross-reference to Array.from

### DIFF
--- a/types & grammar/ch3.md
+++ b/types & grammar/ch3.md
@@ -285,6 +285,8 @@ In other words, it ends up calling `Array(..)` basically like this: `Array(undef
 
 While `Array.apply( null, { length: 3 } )` is a strange and verbose way to create an array filled with `undefined` values, it's **vastly** better and more reliable than what you get with the footgun'ish `Array(3)` empty slots.
 
+**Note:** An alternative way to create an array filled with `undefined` values is to use ES6's `Array.from` static function: `Array.from({length:3})`. See the "`Array.from(..)` Static Function" section in Chapter 6 for more details
+
 Bottom line: **never ever, under any circumstances**, should you intentionally create and use these exotic empty-slot arrays. Just don't do it. They're nuts.
 
 ### `Object(..)`, `Function(..)`, and `RegExp(..)`


### PR DESCRIPTION
In Chapter 3 of Grammar and Types, I've added a note about using `Array.from` for creating Array without empty slots, with a reference to the Chapter that goes deeper into it. I thought it would be useful since `Array.from` is both syntactically simpler and more modern way to do it.