### PR TITLE
Change ES7 to EcmaScript

### DIFF
--- a/types & grammar/ch5.md
+++ b/types & grammar/ch5.md
@@ -95,7 +95,7 @@ a;	// 42
 
 Yeeeaaahhhh. That's terribly ugly. But it works! And it illustrates the point that statement completion values are a real thing that can be captured not just in our console but in our programs.
 
-There's a proposal for ES7 called "do expression." Here's how it might work:
+There's a proposal for EcmaScript called "do expression." Here's how it might work:
 
 ```js
 var a, b;


### PR DESCRIPTION
ES7 isn't a thing, but it normally referenced what comes after ES6 which is ES2016 which has already shipped and ES2017 will ship soon too (without `do`). So I think `EcmaScript` makes the most sense here.

I realize that this may be considered a typo. Feel free to close if you don't care :)