### PR TITLE
typo - baz(); should be bar();  confuses the whole explanation of closure.

### DIFF
--- a/scope & closures/ch5.md
+++ b/scope & closures/ch5.md
@@ -68,7 +68,7 @@ function foo() {
 
 var baz = foo();
 
-baz(); // 2 -- Whoa, closure was just observed, man.
+bar(); // 2 -- Whoa, closure was just observed, man.
 ```
 
 The function `bar()` has lexical scope access to the inner scope of `foo()`. But then, we take `bar()`, the function itself, and pass it *as* a value. In this case, we `return` the function object itself that `bar` references.


### PR DESCRIPTION
I ran the code containing this typo thinking whaaa? I can make a variable into a function somehow?  Closure is even more confusing than I thought! But it was just a typo.  :-)

Or do I have this wrong? 
Here is the story.

I'm trying to understand closure.  

If I run the code as written, I get a `TypeError: baz is not a function`.
So I figured it must be a typo and the author really meant to type `bar();`  I run the change, and the console prints the correct answer (2).  So far so good. 

Then I try to understand by re-reading the chapter text with my corrected code in mind and and it STILL confuses me.

I read this:
> _After we execute foo(), we assign the value it returned (our inner bar() function) to a variable called baz, and **then we actually invoke baz()**, which of course is invoking our inner function bar(), just by a different identifier reference._

Is this text written correctly?  Can we actually invoke `baz` as a function `baz()`?  Is this user error or author error?

(And if it's me, could you explain the invoking baz() thing a little more?)

