### PR TITLE
Update ch1.md

### DIFF
--- a/types & grammar/ch1.md
+++ b/types & grammar/ch1.md
@@ -203,7 +203,7 @@ if (DEBUG) {
 }
 
 // this is a safe existence check
-if (typeof DEBUG !== "undefined") {
+if (typeof DEBUG !== "undefined" && DEBUG) {
 	console.log( "Debugging is starting" );
 }
 ```


### PR DESCRIPTION
Second part of the snippet (which is changed in this commit) is supposed to do just the same as the first part (`if (DEBUG) ...`), but checking the existence of the `DEBUG` variable. But current condition makes it log "Debugging is starting" even if the `DEBUG` variable is set to `false` or another 'falsy' value. So before logging the debugging message we need to check whether the debug is active.
