### PR TITLE
Clarification on the const definition

### DIFF
--- a/scope & closures/ch3.md
+++ b/scope & closures/ch3.md
@@ -579,7 +579,7 @@ See Appendix B for an alternate (more explicit) style of block-scoping which may
 
 ### `const`
 
-In addition to `let`, ES6 introduces `const`, which also creates a block-scoped variable, but whose value is fixed (constant). Any attempt to change that value at a later time results in an error.
+In addition to `let`, ES6 introduces `const`, which also creates a block-scoped variable, but whose binding is fixed (constant). Any attempt to change that binding at a later time results in an error.  The value that the variable refers to, however, is mutable.  If you want to create an immutable object, then use Object.freeze(obj).
 
 ```js
 var foo = true;

--- a/scope & closures/ch3.md
+++ b/scope & closures/ch3.md
@@ -587,13 +587,16 @@ var foo = true;
 if (foo) {
 	var a = 2;
 	const b = 3; // block-scoped to the containing `if`
-
+	const c = {}; // mutable value block-scoped to the containing `if` 
+	
 	a = 3; // just fine!
 	b = 4; // error!
+	c.foo = 42; // just fine!
 }
 
 console.log( a ); // 3
 console.log( b ); // ReferenceError!
+console.log( c ); // [foo: 42]
 ```
 
 ## Review (TL;DR)


### PR DESCRIPTION
ES6 const does not indicate that a value is ‘constant’ or immutable. A const value can change. Instead, it is the binding that is fixed, or constant.

The following is perfectly valid ES6 code that does not throw an exception:

const foo = {};
foo.bar = 42;
console.log(foo.bar);
// → 42

**Yes, I promise I've read the [Contributions Guidelines](https://github.com/getify/You-Dont-Know-JS/blob/master/CONTRIBUTING.md)** (please feel free to remove this line).
