### PR TITLE
fix typo, chapter 3, line 1486

### DIFF
--- a/async & performance/ch3.md
+++ b/async & performance/ch3.md
@@ -1483,7 +1483,7 @@ While native ES6 Promises come with built-in `Promise.all([ .. ])` and `Promise.
 
 * `none([ .. ])` is like `all([ .. ])`, but fulfillments and rejections are transposed. All Promises need to be rejected -- rejections become the fulfillment values and vice versa.
 * `any([ .. ])` is like `all([ .. ])`, but it ignores any rejections, so only one needs to fulfill instead of *all* of them.
-* `first([ .. ])` is a like a race with `any([ .. ])`, which is that it ignores any rejections and fulfills as soon as the first Promise fulfills.
+* `first([ .. ])` is like a race with `any([ .. ])`, which is that it ignores any rejections and fulfills as soon as the first Promise fulfills.
 * `last([ .. ])` is like `first([ .. ])`, but only the latest fulfillment wins.
 
 Some Promise abstraction libraries provide these, but you could also define them yourself using the mechanics of Promises, `race([ .. ])` and `all([ .. ])`.


### PR DESCRIPTION
Removes characters `a ` in line 1486 of async & performance chapter. 