### PR TITLE
modify isSafeInteger polyfill

### DIFF
--- a/types & grammar/ch2.md
+++ b/types & grammar/ch2.md
@@ -446,7 +446,7 @@ To polyfill `Number.isSafeInteger(..)` in pre-ES6 browsers:
 if (!Number.isSafeInteger) {
 	Number.isSafeInteger = function(num) {
 		return Number.isInteger( num ) &&
-			Math.abs( num ) <= Number.MAX_SAFE_INTEGER;
+			Math.abs( num ) <= Math.pow(2, 53) - 1;
 	};
 }
 ```


### PR DESCRIPTION
__Number.MAX_SAFE_INTEGER__ is defined by ES6, so __Number.MAX_SAFE_INTEGER__ should be replaced by  __Math.pow(2, 53) - 1__ there.
