### PR TITLE
Rephrase note about 'promisory'

### DIFF
--- a/async & performance/ch3.md
+++ b/async & performance/ch3.md
@@ -1963,7 +1963,7 @@ Wow, that was pretty easy!
 
 The act of wrapping a callback-expecting function to be a Promise-aware function is sometimes referred to as "lifting" or "promisifying". But there doesn't seem to be a standard term for what to call the resultant function other than a "lifted function", so I like "promisory" better as I think it's more descriptive.
 
-**Note:** Promisory isn't a made-up term. It's a real word, and its definition means to contain or convey a promise. That's exactly what these functions are doing, so it turns out to be a pretty perfect terminology match!
+**Note:** Promisory is derived from a real word, "promissory". Its definition means to contain or convey a promise. That's exactly what these functions are doing, so it turns out to be a pretty perfect terminology match!
 
 So, `Promise.wrap(ajax)` produces an `ajax(..)` promisory we call `request(..)`, and that promisory produces Promises for Ajax responses.
 


### PR DESCRIPTION
The correct spelling is 'promissory'.
See: https://www.merriam-webster.com/dictionary/promissory

