### PR TITLE
Update ch5.md Line 472

### DIFF
--- a/scope & closures/ch5.md
+++ b/scope & closures/ch5.md
@@ -470,6 +470,7 @@ var MyModules = (function Manager() {
 	function define(name, deps, impl) {
 		for (var i=0; i<deps.length; i++) {
 			deps[i] = modules[deps[i]];
+			// above line is confusing me.
 		}
 		modules[name] = impl.apply( impl, deps );
 	}


### PR DESCRIPTION
I've had no problem following the book, but on line 472 there is a syntax construction that has me completely baffled:

    deps[i] = modules[deps[i]];

I checked and this works, but I can't figure out exactly what it does or even why it's legal. It seems to be referencing a non-existent modules property, which should assign undefined to that slot in deps. I don't see how making all items in deps undefined does anything useful.  

Could you put in a word about what it's doing and how, please? :-)

**Yes, I promise I've read the [Contributions Guidelines](https://github.com/getify/You-Dont-Know-JS/blob/master/CONTRIBUTING.md)** (please feel free to remove this line).
