### PR TITLE
Update ch5.md

### DIFF
--- a/scope & closures/ch5.md
+++ b/scope & closures/ch5.md
@@ -469,7 +469,7 @@ var MyModules = (function Manager() {
 
 	function define(name, deps, impl) {
 		for (var i=0; i<deps.length; i++) {
-			deps[i] = modules[deps[i]];
+			deps[i] = get(deps[i]);
 		}
 		modules[name] = impl.apply( impl, deps );
 	}


### PR DESCRIPTION
I think using the get() function in the define() function is better. It makes us easier to understand that we want to set dependent modules to the deps array. It helps us to have one place to change if you want to check if the dependant module is already available. Also it shows us that we can use the get() function inside the define() function to consolidate what we are learning about closure scope. Thanks for writing this great book.

I just read the CONTRIBUTING.md after reading the ** below and could see that you're quite strict with the contributions. If you don't agree with my PR, please let me know and I can delete it.

**Yes, I promise I've read the [Contributions Guidelines](https://github.com/getify/You-Dont-Know-JS/blob/master/CONTRIBUTING.md)** (please feel free to remove this line).