### PR TITLE
maybe `&& oThis` part of check should be removed

### DIFF
--- a/this & object prototypes/ch2.md
+++ b/this & object prototypes/ch2.md
@@ -537,8 +537,7 @@ if (!Function.prototype.bind) {
 			fBound = function(){
 				return fToBind.apply(
 					(
-						this instanceof fNOP &&
-						oThis ? this : oThis
+						this instanceof fNOP ? this : oThis
 					),
 					aArgs.concat( Array.prototype.slice.call( arguments ) )
 				);


### PR DESCRIPTION
For example, if `bind` call was like `foo = foo.bind(null, 1)`
And then we construct new object like `new foo(2)`
In this case `this instanceof fNOP && oThis` evaluates to false and we will use 'oThis` as `this` binding instead of newly created object

**This is why you have the error mentioned in https://github.com/getify/You-Dont-Know-JS/issues/470**

I'm sorry for creating PR without reading Contributions Guidelines, but I've just ran into this typo and decided to help :)

And then I saw that issue is already reported

