### PR TITLE
minor typo: remove 'be' from 'be become'

### DIFF
--- a/types & grammar/ch5.md
+++ b/types & grammar/ch5.md
@@ -464,7 +464,7 @@ var a = res.a;
 var b = res.b;
 ```
 
-**Note:** `{ a, b }` is actually ES6 destructuring shorthand for `{ a: a, b: b }`, so either will work, but it's expected that the shorter `{ a, b }` will be become the preferred form.
+**Note:** `{ a, b }` is actually ES6 destructuring shorthand for `{ a: a, b: b }`, so either will work, but it's expected that the shorter `{ a, b }` will become the preferred form.
 
 Object destructuring with a `{ .. }` pair can also be used for named function arguments, which is sugar for this same sort of implicit object property assignment:
 


### PR DESCRIPTION
After removing the typo, the latter part of the sentence is still a little unclear: if either form works, then will most developers prefer the shorter form because it's shorter? Or is it better in some other way?
