### PR TITLE
Wrong error type

### DIFF
--- a/scope & closures/ch1.md
+++ b/scope & closures/ch1.md
@@ -285,7 +285,7 @@ The JavaScript *Engine* first compiles code before it executes, and in so doing,
 
 Both LHS and RHS reference look-ups start at the currently executing *Scope*, and if need be (that is, they don't find what they're looking for there), they work their way up the nested *Scope*, one scope (floor) at a time, looking for the identifier, until they get to the global (top floor) and stop, and either find it, or don't.
 
-Unfulfilled RHS references result in `ReferenceError`s being thrown. Unfulfilled LHS references result in an automatic, implicitly-created global of that name (if not in "Strict Mode" [^note-strictmode]), or a `ReferenceError` (if in "Strict Mode" [^note-strictmode]).
+Unfulfilled RHS references result in `TypeError`s being thrown. Unfulfilled LHS references result in an automatic, implicitly-created global of that name (if not in "Strict Mode" [^note-strictmode]), or a `ReferenceError` (if in "Strict Mode" [^note-strictmode]).
 
 ### Quiz Answers
 


### PR DESCRIPTION
an unfulfilled RHS should throw `TypeError` as it happens when an impossible action is being performed such as retrieve a property on `undefined`.

**Yes, I promise I've read the [Contributions Guidelines](https://github.com/getify/You-Dont-Know-JS/blob/master/CONTRIBUTING.md)** (please feel free to remove this line).
