### PR TITLE
this & object prototypes (ch3.md): Fixed output comment

### DIFF
--- a/this & object prototypes/ch3.md
+++ b/this & object prototypes/ch3.md
@@ -808,7 +808,9 @@ var myArray = [1, 2, 3];
 for (var i = 0; i < myArray.length; i++) {
 	console.log( myArray[i] );
 }
-// 1 2 3
+// 1
+// 2
+// 3
 ```
 
 This isn't iterating over the values, though, but iterating over the indices, where you then use the index to reference the value, as `myArray[i]`.


### PR DESCRIPTION
Code snippet had comments to represent the output
of that same snippet. Those comments were showing
the output without the line breaks.

**Yes, I promise I've read the [Contributions Guidelines](https://github.com/getify/You-Dont-Know-JS/blob/master/CONTRIBUTING.md)** (please feel free to remove this line).
