### PR TITLE
Add missing spaces in statement 'var i=0'

### DIFF
--- a/up & going/ch1.md
+++ b/up & going/ch1.md
@@ -570,7 +570,7 @@ for (var i = 0; i <= 9; i = i + 1) {
 
 As you can see, in both cases the conditional `i <= 9` is `true` for the first 10 iterations (`i` of values `0` through `9`) of either loop form, but becomes `false` once `i` is value `10`.
 
-The `for` loop has three clauses: the initialization clause (`var i=0`), the conditional test clause (`i <= 9`), and the update clause (`i = i + 1`). So if you're going to do counting with your loop iterations, `for` is a more compact and often easier form to understand and write.
+The `for` loop has three clauses: the initialization clause (`var i = 0`), the conditional test clause (`i <= 9`), and the update clause (`i = i + 1`). So if you're going to do counting with your loop iterations, `for` is a more compact and often easier form to understand and write.
 
 There are other specialized loop forms that are intended to iterate over specific values, such as the properties of an object (see Chapter 2) where the implied conditional test is just whether all the properties have been processed. The "loop until a condition fails" concept holds no matter what the form of the loop.
 


### PR DESCRIPTION
Changed the part 'var i=0' to 'var i = 0' to make sure code snippets follow consistency throughout the book.
