### PR TITLE
Avoid use of "obviously" in Types & Grammar intro

### DIFF
--- a/types & grammar/ch1.md
+++ b/types & grammar/ch1.md
@@ -23,7 +23,7 @@ Beyond academic definition disagreements, why does it matter if JavaScript has *
 
 Having a proper understanding of each *type* and its intrinsic behavior is absolutely essential to understanding how to properly and accurately convert values to different types (see Coercion, Chapter 4). Nearly every JS program ever written will need to handle value coercion in some shape or form, so it's important you do so responsibly and with confidence.
 
-If you have the `number` value `42`, but you want to treat it like a `string`, such as pulling out the `"2"` as a character in position `1`, you obviously must first convert (coerce) the value from `number` to `string`.
+If you have the `number` value `42`, but you want to treat it like a `string`, such as pulling out the `"2"` as a character in position `1`, you must first convert (coerce) the value from `number` to `string`.
 
 That seems simple enough.
 


### PR DESCRIPTION
The word `obvious` and `obviously` aren't always bad to use. But as part of an explanation, I find that is is almost always out of place, given the intended audience may very well not know (and expectedly so).

I think its removal in this case improves the content for everyone.

See also: <https://css-tricks.com/words-avoid-educational-writing/>