### PR TITLE
added ACCESSORY_PRICE to the calculation of affordability

### DIFF
--- a/up & going/ch1.md
+++ b/up & going/ch1.md
@@ -477,7 +477,7 @@ var amount = 99.99;
 amount = amount * 2;
 
 // can we afford the extra purchase?
-if ( amount < bank_balance ) {
+if ( amount + ACCESSORY_PRICE < bank_balance ) {
 	console.log( "I'll take the accessory!" );
 	amount = amount + ACCESSORY_PRICE;
 }
@@ -487,7 +487,7 @@ else {
 }
 ```
 
-Here, if `amount < bank_balance` is `true`, we'll print out `"I'll take the accessory!"` and add the `9.99` to our `amount` variable. Otherwise, the `else` clause says we'll just politely respond with `"No, thanks."` and leave `amount` unchanged.
+Here, if `amount + ACCESSORY_PRICE < bank_balance` is `true`, we'll print out `"I'll take the accessory!"` and add the `9.99` to our `amount` variable. Otherwise, the `else` clause says we'll just politely respond with `"No, thanks."` and leave `amount` unchanged.
 
 As we discussed in "Values & Types" earlier, values that aren't already of an expected type are often coerced to that type. The `if` statement expects a `boolean`, but if you pass it something that's not already `boolean`, coercion will occur.
 


### PR DESCRIPTION
In the base/original: If the 'bank_balance' variable were less than 209.97 but greater than 199.98, the old expression would evaluate and claim we could afford the extra purchase, but we wouldn't actually be able to afford it because the bank balance would be less than the 'amount' + 'ACCESSORY_PRICE'.

In my PR: affordability is determined by adding both the 'amount' variable and 'ACCESSORY_PRICE' constant and then checking if that total is less than the 'bank_balance' variable.

This just bothered me when I read it and imagined the overdraft fees in the breaking test cases for some poor chap. Hope I'm not being too nit-picky or totally missing something.