### PR TITLE
Corrected example to use obj instead of window

### DIFF
--- a/this & object prototypes/ch2.md
+++ b/this & object prototypes/ch2.md
@@ -285,7 +285,7 @@ setTimeout( bar, 100 ); // 2
 
 // `bar` hard binds `foo`'s `this` to `obj`
 // so that it cannot be overriden
-bar.call( window ); // 2
+bar.call( obj ); // 2
 ```
 
 Let's examine how this variation works. We create a function `bar()` which, internally, manually calls `foo.call(obj)`, thereby forcibly invoking `foo` with `obj` binding for `this`. No matter how you later invoke the function `bar`, it will always manually invoke `foo` with `obj`. This binding is both explicit and strong, so we call it *hard binding*.


### PR DESCRIPTION
The one-line diff is hopefully self-explanatory, the example should use obj and not window to work as intended.