### PR TITLE
Remove unused variable in example

### DIFF
--- a/this & object prototypes/ch2.md
+++ b/this & object prototypes/ch2.md
@@ -776,7 +776,7 @@ Let's illustrate arrow-function lexical scope:
 ```js
 function foo() {
 	// return an arrow function
-	return (a) => {
+	return () => {
 		// `this` here is lexically adopted from `foo()`
 		console.log( this.a );
 	};


### PR DESCRIPTION
Removing the unused parameter to remove a potential source of confusion, a is such a popular symbol name in these examples .. :)
