### PR TITLE
Added error in example where it should be

### DIFF
--- a/types & grammar/ch5.md
+++ b/types & grammar/ch5.md
@@ -1047,7 +1047,7 @@ Another example of a TDZ violation can be seen with ES6 default parameter values
 ```js
 var b = 3;
 
-function foo( a = 42, b = a + b + 5 ) {
+function foo( a = 42, b = a + b + 5 ) {	// ReferenceError!
 	// ..
 }
 ```


### PR DESCRIPTION
I added a comment specifying an error in an example where it happens but was forgotten. 