### PR TITLE
Fixed missing Patreon image

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you like the content you find here, and want to support more content like it,
 
 If you'd like to contribute financially towards the effort (or any of my other OSS work) aside from purchasing the books, I do have a [patreon](https://www.patreon.com/getify) that I would always appreciate your generosity towards.
 
-<a href="https://www.patreon.com/getify">[![patreon.png](https://s13.postimg.org/k9nkc5thz/become_a_patron_button.png)](https://www.patreon.com/getify)</a>
+<a href="https://www.patreon.com/getify">[![patreon.png](https://c5.patreon.com/external/logo/become_a_patron_button.png)](https://www.patreon.com/getify)</a>
 
 ## In-person Training
 


### PR DESCRIPTION
The previous image was not available anymore. Replaced it with a direct link to the one on [https://www.patreon.com/brand/downloads](https://www.patreon.com/brand/downloads)
