### PR TITLE
Argument is not needed in arrow function

### DIFF
--- a/this & object prototypes/ch2.md
+++ b/this & object prototypes/ch2.md
@@ -776,7 +776,7 @@ Let's illustrate arrow-function lexical scope:
 ```js
 function foo() {
 	// return an arrow function
-	return (a) => {
+	return () => {
 		// `this` here is lexically adopted from `foo()`
 		console.log( this.a );
 	};


### PR DESCRIPTION
Since the example is illustrating that the function takes its `this` from the enclosing scope, it doesn't need any arguments.
