### PR TITLE
Corrected typo that indicated writable:false indicated not read-only …

### DIFF
--- a/this & object prototypes/ch5.md
+++ b/this & object prototypes/ch5.md
@@ -94,7 +94,7 @@ If the property name `foo` ends up both on `myObject` itself and at a higher lev
 
 As we just hinted, shadowing `foo` on `myObject` is not as simple as it may seem. We will now examine three scenarios for the `myObject.foo = "bar"` assignment when `foo` is **not** already on `myObject` directly, but **is** at a higher level of `myObject`'s `[[Prototype]]` chain:
 
-1. If a normal data accessor (see Chapter 3) property named `foo` is found anywhere higher on the `[[Prototype]]` chain, **and it's not marked as read-only (`writable:false`)** then a new property called `foo` is added directly to `myObject`, resulting in a **shadowed property**.
+1. If a normal data accessor (see Chapter 3) property named `foo` is found anywhere higher on the `[[Prototype]]` chain, **and it's not marked as read-only (`writable:true`)** then a new property called `foo` is added directly to `myObject`, resulting in a **shadowed property**.
 2. If a `foo` is found higher on the `[[Prototype]]` chain, but it's marked as **read-only (`writable:false`)**, then both the setting of that existing property as well as the creation of the shadowed property on `myObject` **are disallowed**. If the code is running in `strict mode`, an error will be thrown. Otherwise, the setting of the property value will silently be ignored. Either way, **no shadowing occurs**.
 3. If a `foo` is found higher on the `[[Prototype]]` chain and it's a setter (see Chapter 3), then the setter will always be called. No `foo` will be added to (aka, shadowed on) `myObject`, nor will the `foo` setter be redefined.
 


### PR DESCRIPTION
…(page 88 in print version)

Noticed this while reading today. writable:false would indicate the property is read-only but the text reads "...it's not marked as read-only (writable:false)"  I'm pretty sure that should be writable:true.
