### PR TITLE
Update es6 & beyond - Chapter 5: Collections - TypedArray constructor description

### DIFF
--- a/es6 & beyond/ch5.md
+++ b/es6 & beyond/ch5.md
@@ -108,7 +108,7 @@ var first = new Uint16Array( buf, 0, 2 )[0],
 
 In addition to the `(buffer,[offset, [length]])` form examined in the previous section, typed array constructors also support these forms:
 
-* [constructor]`(length)`: Creates a new view over a new buffer of `length` bytes
+* [constructor]`(length)`: Creates a new view over a new buffer of `length`  multiplied by TypedArray.BYTES_PER_ELEMENT bytes
 * [constructor]`(typedArr)`: Creates a new view and buffer, and copies the contents from the `typedArr` view
 * [constructor]`(obj)`: Creates a new view and buffer, and iterates over the array-like or object `obj` to copy its contents
 


### PR DESCRIPTION
As mentioned in MDN and other sources TypedArray(length) constructor makes a view of `length` elements not bytes.
It can be also tested by:
```javascript
var x = new Uint32Array(2);
console.log(x.length) // 2
console.log(x.byteLength) // 8
x[1] = 25;
console.log(x[1]); // 25
```
