### PR TITLE
Fix spacing in function params

### DIFF
--- a/scope & closures/ch5.md
+++ b/scope & closures/ch5.md
@@ -162,7 +162,7 @@ Deep down in the guts of the *Engine*, the built-in utility `setTimeout(..)` has
 Or, if you're of the jQuery persuasion (or any JS framework, for that matter):
 
 ```js
-function setupBot(name,selector) {
+function setupBot(name, selector) {
 	$( selector ).click( function activator(){
 		console.log( "Activating: " + name );
 	} );


### PR DESCRIPTION
Fix spacing in function params. Params are separated by space in other chapters.