### PR TITLE
"abc".match( RegExp.prototype ) gives an error

### DIFF
--- a/types & grammar/ch3.md
+++ b/types & grammar/ch3.md
@@ -429,7 +429,7 @@ typeof Function.prototype;			// "function"
 Function.prototype();				// it's an empty function!
 
 RegExp.prototype.toString();		// "/(?:)/" -- empty regex
-"abc".match( RegExp.prototype );	// [""]
+"abc".match( RegExp.prototype.toString() );	// null (when `String#match(...)` does not find a match, it returns null)
 ```
 
 A particularly bad idea, you can even modify these native prototypes (not just adding properties as you're probably familiar with):


### PR DESCRIPTION
When you call "abc".match( RegExp.prototype ) the console will give an error:  Method RegExp.prototype.exec called on incompatible receiver [object Object]

To avoid this, you need to convert RegExp.prototype to a String, like this:

 "abc".match( RegExp.prototype.toString() ); "null"

which returns null because the match method could not find any string with the pattern of "/(?:)/".

When match finds something it will return an Array Object, for example: "abc".match(/ab/); returns ["ab"];

**Yes, I promise I've read the [Contributions Guidelines](https://github.com/getify/You-Dont-Know-JS/blob/master/CONTRIBUTING.md)** (please feel free to remove this line).
