### PR TITLE
Miss a '9' in the calculation result

### DIFF
--- a/types & grammar/apA.md
+++ b/types & grammar/apA.md
@@ -369,10 +369,10 @@ for (var i=1; i < 100000; i++) {
 }
 
 addAll( 2, 4, 6 );				// 12
-addAll.apply( null, nums );		// should be: 499950000
+addAll.apply( null, nums );		// should be: 4999950000
 ```
 
-In some JS engines, you'll get the correct `499950000` answer, but in others (like Safari 6.x), you'll get the error: "RangeError: Maximum call stack size exceeded."
+In some JS engines, you'll get the correct `4999950000` answer, but in others (like Safari 6.x), you'll get the error: "RangeError: Maximum call stack size exceeded."
 
 Examples of other limits known to exist:
 


### PR DESCRIPTION
![2019-01-22 23_15_53-you-dont-know-js_apa md at master getify_you-dont-know-js](https://user-images.githubusercontent.com/5885902/51589405-b5c71c80-1e9b-11e9-8e24-e30f0156406c.png)

Chrome Debugger confirmed this.