### PR TITLE
States pre-ES6 Number.isSafeInteger(..) polyfill dependency

### DIFF
--- a/types & grammar/ch2.md
+++ b/types & grammar/ch2.md
@@ -440,7 +440,7 @@ Number.isSafeInteger( Math.pow( 2, 53 ) );			// false
 Number.isSafeInteger( Math.pow( 2, 53 ) - 1 );		// true
 ```
 
-To polyfill `Number.isSafeInteger(..)` in pre-ES6 browsers:
+To polyfill `Number.isSafeInteger(..)` in pre-ES6 browsers combine the following with the `Number.isInteger(..)` pre-ES6 polyfill:
 
 ```js
 if (!Number.isSafeInteger) {


### PR DESCRIPTION
The pre-ES6 `Number.isSafeInteger(..)` polyfill depends on the pre-ES6 `Number.isInteger(..)` polyfill provided earlier in this section. This PR updates the pre-ES6 `Number.isSafeInteger(..)` polyfill’s description to explicitly mention that dependency since it could be missed by & confuse readers who attempt to use it in pre-ES6 environments without the dependency.

**Yes, I promise I've read the [Contributions Guidelines](https://github.com/getify/You-Dont-Know-JS/blob/master/CONTRIBUTING.md)**.