### PR TITLE
this & Object Prototypes: 3: Type & Review: complex & primary

### DIFF
--- a/this & object prototypes/ch3.md
+++ b/this & object prototypes/ch3.md
@@ -38,11 +38,11 @@ Objects are the general building block upon which much of JS is built. They are 
 * `undefined`
 * `object`
 
-Note that the *simple primitives* (`string`, `number`, `boolean`, `null`, and `undefined`) are **not** themselves `objects`. `null` is sometimes referred to as an object type, but this misconception stems from a bug in the language which causes `typeof null` to return the string `"object"` incorrectly (and confusingly). In fact, `null` is its own primitive type.
-
 **It's a common mis-statement that "everything in JavaScript is an object". This is clearly not true.**
 
-By contrast, there *are* a few special object sub-types, which we can refer to as *complex primitives*.
+Note that the *simple primitives* (`string`, `number`, `boolean`, `null`, and `undefined`) are **not** themselves `objects`. `null` is sometimes referred to as an object type, but this misconception stems from a bug in the language which causes `typeof null` to return the string `"object"` incorrectly (and confusingly). In fact, `null` is its own primitive type.
+
+By contrast, there *are* a few special object sub-types, which we can refer to as *complex primitives* (`String`, `Number`, and `Boolean`).
 
 `function` is a sub-type of object (technically, a "callable object"). Functions in JS are said to be "first class" in that they are basically just normal objects (with callable behavior semantics bolted on), and so they can be handled like any other plain object.
 
@@ -50,7 +50,7 @@ Arrays are also a form of objects, with extra behavior. The organization of cont
 
 ### Built-in Objects
 
-There are several other object sub-types, usually referred to as built-in objects. For some of them, their names seem to imply they are directly related to their simple primitives counter-parts, but in fact, their relationship is more complicated, which we'll explore shortly.
+There are several other object sub-types, usually referred to as built-in objects. For some of them, complex primitives, their names seem to imply they are directly related to their simple primitives counter-parts, but in fact, their relationship is more complicated, which we'll explore shortly.
 
 * `String`
 * `Number`
@@ -935,7 +935,7 @@ This iterator will generate random numbers "forever", so we're careful to only p
 
 Objects in JS have both a literal form (such as `var a = { .. }`) and a constructed form (such as `var a = new Array(..)`). The literal form is almost always preferred, but the constructed form offers, in some cases, more creation options.
 
-Many people mistakenly claim "everything in JavaScript is an object", but this is incorrect. Objects are one of the 6 (or 7, depending on your perspective) primitive types. Objects have sub-types, including `function`, and also can be behavior-specialized, like `[object Array]` as the internal label representing the array object sub-type.
+Many people mistakenly claim "everything in JavaScript is an object", but this is incorrect. Objects are one of the 6 (or 7, depending on your perspective) primary types. Objects have sub-types, including `function`, and also can be behavior-specialized, like `[object Array]` as the internal label representing the array object sub-type.
 
 Objects are collections of key/value pairs. The values can be accessed as properties, via `.propName` or `["propName"]` syntax. Whenever a property is accessed, the engine actually invokes the internal default `[[Get]]` operation (and `[[Put]]` for setting values), which not only looks for the property directly on the object, but which will traverse the `[[Prototype]]` chain (see Chapter 5) if not found.
 


### PR DESCRIPTION
Proposed updates:
* Move ”**mis-statement that everything...is an object**” earlier for more contextual flow. 
* Explicitly list the *complex primitives* (`String`, `Boolean`, and `Number`).
* Correct a seemingly incorrect reference, in the **Review** section: **primary** vs. primitive **types**.

**Yes, I promise I've read the [Contributions Guidelines](https://github.com/getify/You-Dont-Know-JS/blob/master/CONTRIBUTING.md)**.
