### PR TITLE
#1473  Updated chapter 3 - Contents section - Object key name types

### DIFF
--- a/this & object prototypes/ch3.md
+++ b/this & object prototypes/ch3.md
@@ -146,7 +146,7 @@ if (wantA) {
 console.log( myObject[idx] ); // 2
 ```
 
-In objects, property names are **always** strings. If you use any other value besides a `string` (primitive) as the property, it will first be converted to a string. This even includes numbers, which are commonly used as array indexes, so be careful not to confuse the use of numbers between objects and arrays.
+In objects, property names are `strings` expect when using the primitive type `symbol`. If you use any other values besides `string` or `symbol` (primitives) as the property, it will first be converted to a string. This even includes numbers, which are commonly used as array indexes, so be careful not to confuse the use of numbers between objects and arrays.
 
 ```js
 var myObject = { };

--- a/this & object prototypes/ch3.md
+++ b/this & object prototypes/ch3.md
@@ -146,7 +146,7 @@ if (wantA) {
 console.log( myObject[idx] ); // 2
 ```
 
-In objects, property names are `strings` expect when using the primitive type `symbol`. If you use any other values besides `string` or `symbol` (primitives) as the property, it will first be converted to a string. This even includes numbers, which are commonly used as array indexes, so be careful not to confuse the use of numbers between objects and arrays.
+In objects, property names are `string` except when using the primitive type `symbol`. If you use any other values besides `string` or `symbol` (primitives) as the property, it will first be converted to a string. This even includes numbers, which are commonly used as array indexes, so be careful not to confuse the use of numbers between objects and arrays.
 
 ```js
 var myObject = { };


### PR DESCRIPTION
Proposed a change in the text to say that when Symbols are used as keys in objects, it's not coerced into a string primitive.
```
var obj = {}
var firstSymbol = Symbol('hello');
var secondSymbol = Symbol('hello');

console.log(firstSymbol);           // Symbol(hello)
console.log(secondSymbol);     // Symbol(hello)

obj[firstSymbol] = 'first value';
obj[secondSymbol] = 'second value';

console.log(obj[firstSymbol]);             // first value
console.log(obj[secondSymbol]);       // second value

console.log(obj["Symbol(hello)"])      // undefined

```

**Yes, I promise I've read the [Contributions Guidelines](https://github.com/getify/You-Dont-Know-JS/blob/master/CONTRIBUTING.md)** (please feel free to remove this line).
