### PR TITLE
Remove gendered pronouns

### DIFF
--- a/scope & closures/ch1.md
+++ b/scope & closures/ch1.md
@@ -155,7 +155,7 @@ Let's imagine the above exchange (which processes this code snippet) as a conver
 
 > ***Engine***: Hey *Scope*, I have an RHS reference for `foo`. Ever heard of it?
 
-> ***Scope***: Why yes, I have. *Compiler* declared it just a second ago. He's a function. Here you go.
+> ***Scope***: Why yes, I have. *Compiler* declared it just a second ago. It's a function. Here you go.
 
 > ***Engine***: Great, thanks! OK, I'm executing `foo`.
 
@@ -167,13 +167,13 @@ Let's imagine the above exchange (which processes this code snippet) as a conver
 
 > ***Engine***: Hey, *Scope*, sorry to bother you again. I need an RHS look-up for `console`. Ever heard of it?
 
-> ***Scope***: No problem, *Engine*, this is what I do all day. Yes, I've got `console`. He's built-in. Here ya go.
+> ***Scope***: No problem, *Engine*, this is what I do all day. Yes, I've got `console`. It's built-in. Here ya go.
 
 > ***Engine***: Perfect. Looking up `log(..)`. OK, great, it's a function.
 
 > ***Engine***: Yo, *Scope*. Can you help me out with an RHS reference to `a`. I think I remember it, but just want to double-check.
 
-> ***Scope***: You're right, *Engine*. Same guy, hasn't changed. Here ya go.
+> ***Scope***: You're right, *Engine*. Same thing, hasn't changed. Here ya go.
 
 > ***Engine***: Cool. Passing the value of `a`, which is `2`, into `log(..)`.
 


### PR DESCRIPTION
Replace gendered pronouns (‘he’s a function’, ‘same guy’) by matching the format used in later examples (‘Nope, never heard of it. Go fish.’)

**Yes, I promise I've read the [Contributions Guidelines](https://github.com/getify/You-Dont-Know-JS/blob/master/CONTRIBUTING.md)**.
