### PR TITLE
Outer scopes instead if Nested scopes

### DIFF
--- a/scope-closures/ch2.md
+++ b/scope-closures/ch2.md
@@ -21,7 +21,7 @@
 
 ----
 
-In Chapter 1, we defined "scope" as the set of rules that govern how the *Engine* can look up a variable by its identifier name and find it, either in the current *Scope*, or in any of the *Nested Scopes* it's contained within.
+In Chapter 1, we defined "scope" as the set of rules that govern how the *Engine* can look up a variable by its identifier name and find it, either in the current *Scope*, or in any of the *Outer Scopes* it's contained within.
 
 There are two predominant models for how scope works. The first of these is by far the most common, used by the vast majority of programming languages. It's called **Lexical Scope**, and we will examine it in-depth. The other model, which is still used by some languages (such as Bash scripting, some modes in Perl, etc.) is called **Dynamic Scope**.
 


### PR DESCRIPTION
Issue Number:  #1510

"I already searched for this issue":

Edition: (2nd)

Book Title: Scope & Closures

Chapter: Lexical Scope

Section Title: Introduction: First Paragraph

Problem:
The first paragraph reads as follows:

In Chapter 1, we defined "scope" as the set of rules that govern how the Engine can look up a variable by its identifier name and find it, either in the current Scope, ### or in any of the Nested Scopes it's contained within.

I think the last sentence is confusing because of the incorrect use of the term "Nested Scopes" because:

'Nested Scopes' implies that the scopes are contained within the current scope, and it contradicts with the second part of the sentence "it's contained within".

I think the correct sentence would be:
"... either in the current Scope, or in any of the OUTER Scopes it's contained within."

Thank you

**Yes, I promise I've read the [Contributions Guidelines](https://github.com/getify/You-Dont-Know-JS/blob/master/CONTRIBUTING.md)** (please feel free to remove this line).

----

**Please type "I already searched for this issue":**

**Edition:** (1st or 2nd)

**Book Title:**

**Chapter:**

**Section Title:**

**Topic:**
