### PR TITLE
code snippet changed to have both forms of writing IIFE shown.

### DIFF
--- a/scope & closures/ch3.md
+++ b/scope & closures/ch3.md
@@ -260,7 +260,7 @@ var a = 2;
 	var a = 3;
 	console.log( a ); // 3
 
-})();
+}());
 
 console.log( a ); // 2
 ```


### PR DESCRIPTION
below the "Function Expressions Immediately" part, the text talks about two forms of immediately invoking a function expression. but both the codes are using the traditional form. (they both place the invoke operator() outside of the wrapping parentheses.)
In the second snippet I moved the parentheses of invoking, into the wrapping parentheses, so that there is at least one snippet which uses the second form of writing IIFE.

**Yes, I promise I've read the [Contributions Guidelines](https://github.com/getify/You-Dont-Know-JS/blob/master/CONTRIBUTING.md)** (please feel free to remove this line).

----

** "I already searched for this issue":**

**Edition:** 
2nd edition
**Book Title:**
 Scope and Closures
**Chapter:**
Function Versus Block Scope
**Section Title:**
Functions as Scopes
**Topic:**
Invoking Function Expressions Immediately