### PR TITLE
2nd ed

### DIFF
--- a/types-grammar/ch4.md
+++ b/types-grammar/ch4.md
@@ -1200,7 +1200,7 @@ Both `||` and `&&` operators perform a `boolean` test on the **first operand** (
 
 For the `||` operator, if the test is `true`, the `||` expression results in the value of the *first operand* (`a` or `c`). If the test is `false`, the `||` expression results in the value of the *second operand* (`b`).
 
-Inversely, for the `&&` operator, if the test is `true`, the `&&` expression results in the value of the *second operand* (`b`). If the test is `false`, the `&&` expression results in the value of the *first operand* (`a` or `c`).
+Inversely, for the `&&` operator, if the test is `true`, the `&&` expression results in the value of the *second operand* (`b`). If the test is `false`, the `&&` expression results in the value of the *falsy operand* (`a`, `b` or `c`).
 
 The result of a `||` or `&&` expression is always the underlying value of one of the operands, **not** the (possibly coerced) result of the test. In `c && b`, `c` is `null`, and thus falsy. But the `&&` expression itself results in `null` (the value in `c`), not in the coerced `false` used in the test.
 

--- a/types-grammar/ch4.md
+++ b/types-grammar/ch4.md
@@ -1850,7 +1850,7 @@ The algorithm first calls `ToPrimitive` coercion on both values, and if the retu
 For example:
 
 ```js
-var a = [ 42 ];
+var a = 42;
 var b = [ "43" ];
 
 a < b;	// true


### PR DESCRIPTION
1. In the **Operators `||` and `&&`** section, there is a sentence that says:
```
If the test is `false`, the `&&` expression results in the value of the *first operand* (`a` or `c`)
```
For example:
```javascript
console.log(true && '')
```
It will result in the second operand.

2. In the **Abstract Relational Comparison section** you said:
```
The algorithm first calls `ToPrimitive` coercion on both values, and if the return result of either call is not a `string`, then both values are coerced to `number` values using the `ToNumber` operation rules, and compared numerically
```
Which its example is wrong because they have been compared alphabetically:
```javascript
[42] < ["43"]
```
Because `[42]` will be "42" and after that "42" will be compared to "43".
As I explained:
```javascript
[42] < ["043"] // false
```
----

**I already searched for this issue**

**Edition:** 2nd

**Book Title:** You-Dont-Know-JS

**Chapter:** Chapter 4: Coercion

**Section Title:** types-grammar

**Topic:** Abstract Relational Comparison & Operators `||` and `&&`
