### PR TITLE
typo: 'strict mide' should be 'strict mode' ?

### DIFF
--- a/get-started/ch1.md
+++ b/get-started/ch1.md
@@ -425,7 +425,7 @@ The strict mode pragma must appear at the top of a file, with only whitespace or
 
 | WARNING: |
 | :--- |
-| Something to be aware of is that even a stray `;` all by itself appearing before the strict mide pragma will render the pragma useless; no errors are thrown because it's valid JS to have a string literal expression in a statement position, but it also will silently *not* turn on strict mode! |
+| Something to be aware of is that even a stray `;` all by itself appearing before the strict mode pragma will render the pragma useless; no errors are thrown because it's valid JS to have a string literal expression in a statement position, but it also will silently *not* turn on strict mode! |
 
 Strict mode can alternatively be turned on per-function scope, with exactly the same rules/admonitions about its positioning):
 

--- a/get-started/ch4.md
+++ b/get-started/ch4.md
@@ -89,7 +89,7 @@ On the other hand, there's a *grain* you really should pay attention to and foll
 
 Can you make your JS program look like a Java, C#, or Perl program? What about Python or Ruby, or even PHP? To varying degrees, sure you can. But should you?
 
-No, I don't think you should. I think you should learn and embrace the JS way, and make your JS programs as JS's as is practical. Some will think that means sloppy and informal programming, but I don't mean that at all. I just mean that JS has a lot of patterns and idioms that are recognizably "JS", and going with that *grain* is the general path to best success.
+No, I don't think you should. I think you should learn and embrace the JS way, and make your JS programs as JS'y as is practical. Some will think that means sloppy and informal programming, but I don't mean that at all. I just mean that JS has a lot of patterns and idioms that are recognizably "JS", and going with that *grain* is the general path to best success.
 
 Finally, maybe the most important *grain* to recognize is how the existing program(s) you're working on, and developers you're working with, do stuff. Don't read these books and then try to change *all that grain* in your existing projects over night. That approach will always fail.
 

--- a/get-started/ch4.md
+++ b/get-started/ch4.md
@@ -89,7 +89,7 @@ On the other hand, there's a *grain* you really should pay attention to and foll
 
 Can you make your JS program look like a Java, C#, or Perl program? What about Python or Ruby, or even PHP? To varying degrees, sure you can. But should you?
 
-No, I don't think you should. I think you should learn and embrace the JS way, and make your JS programs as JS'y as is practical. Some will think that means sloppy and informal programming, but I don't mean that at all. I just mean that JS has a lot of patterns and idioms that are recognizably "JS", and going with that *grain* is the general path to best success.
+No, I don't think you should. I think you should learn and embrace the JS way, and make your JS programs as JS's as is practical. Some will think that means sloppy and informal programming, but I don't mean that at all. I just mean that JS has a lot of patterns and idioms that are recognizably "JS", and going with that *grain* is the general path to best success.
 
 Finally, maybe the most important *grain* to recognize is how the existing program(s) you're working on, and developers you're working with, do stuff. Don't read these books and then try to change *all that grain* in your existing projects over night. That approach will always fail.
 


### PR DESCRIPTION
should be 'strict mode' I guess?

**Please type "I already searched for this issue":**

**Edition:** 2nd-ed

**Book Title:** You Don't Know JS Yet

**Chapter:** Chapter 1: What Is JavaScript?

**Section Title:** Strictly Speaking

**Topic:**
