### PR TITLE
Fix typo - from 'scope' to 'source'.

### DIFF
--- a/scope-closures/ch2.md
+++ b/scope-closures/ch2.md
@@ -226,7 +226,7 @@ One of the most important aspects of lexical scope is that any time an identifie
 
 ### Lookup Failures
 
-When *Engine* exhausts all *lexically available* scopes and still cannot resolve the lookup of an identifier, an error condition then exists. However, depending on the mode of the program (strict-mode or not) and the role of the variable (i.e., *target* vs. *scope*; see Chapter 1), this error condition will be handled differently.
+When *Engine* exhausts all *lexically available* scopes and still cannot resolve the lookup of an identifier, an error condition then exists. However, depending on the mode of the program (strict-mode or not) and the role of the variable (i.e., *target* vs. *source*; see Chapter 1), this error condition will be handled differently.
 
 If the variable is a *source*, an unresolved identifier lookup is considered an undeclared (unknown, missing) variable, which results in a `ReferenceError` being thrown. Also, if the variable is a *target*, and the code at that point is running in strict-mode, the variable is considered undeclared and throws a `ReferenceError`.
 


### PR DESCRIPTION
'scope' should be 'source' in the phrase 'target vs. scope'.

**Please type "I already searched for this issue":** I already searched for this issue.

**Edition:** (pull requests not accepted for previous editions) 2

**Book Title:** Scopes and Closures

**Chapter:** Chapter 2: Understanding Lexical Scope

**Section Title:** Nested Scope

**Topic:** Lookup Failures
