### PR TITLE
generator functions syntax correction

### DIFF
--- a/get-started/apA.md
+++ b/get-started/apA.md
@@ -115,13 +115,13 @@ Here are some more declaration forms:
 
 ```js
 // generator function declaration
-function *two() { .. }
+function* two() { .. }
 
 // async function declaration
 async function three() { .. }
 
 // async generator function declaration
-async function *four() { .. }
+async function* four() { .. }
 
 // named function export declaration (ES6 modules)
 export function five() { .. }


### PR DESCRIPTION
the "*" should be stick to function keyword not the function name;
I already searched for this issue, reference:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*

