### PR TITLE
Typo: insert omitted 'function' keyword

### DIFF
--- a/scope-closures/ch7.md
+++ b/scope-closures/ch7.md
@@ -153,7 +153,7 @@ Now let's examine an example where the closed-over variable is updated:
 function makeCounter() {
     var count = 0;
 
-    return getCurrent(){
+    return function getCurrent() {
         count = count + 1;
         return count;
     };


### PR DESCRIPTION
**Yes, I promise I've read the [Contributions Guidelines](https://github.com/getify/You-Dont-Know-JS/blob/master/CONTRIBUTING.md)** (please feel free to remove this line).

Specifically quoting these guidelines regarding typos:

> Typos?
>
> Please don't worry about minor text typos. These will almost certainly be caught during the editing process.
>
> If you're going to submit a PR for typo fixes, please be measured in doing so by collecting several small changes into a single PR (in separate commits). Or, **just don't even worry about them for now,** because we'll get to them later. I promise.

----

**Please type "I already searched for this issue":**

**Edition:** (pull requests not accepted for previous editions)

**Book Title:**

**Chapter:**

**Section Title:**

**Topic:**
