### PR TITLE
Small Change in Chapter 4 (Types and Grammar)

### DIFF
--- a/types-grammar/ch4.md
+++ b/types-grammar/ch4.md
@@ -1202,9 +1202,9 @@ c && b;		// null
 
 Both `||` and `&&` operators perform a `boolean` test on the **first operand** (`a` or `c`). If the operand is not already `boolean` (as it's not, here), a normal `ToBoolean` coercion occurs, so that the test can be performed.
 
-For the `||` operator, if the test is `true`, the `||` expression results in the value of the *first operand* (`a` or `c`). If the test is `false`, the `||` expression results in the value of the *second operand* (`b`).
+For the `||` operator, if the test is `true`, the `||` expression results in the value of the *first operand* (`a` or `c`). If the test is `false`, the `||` expression results in the value of the *second operand* (`b`) (The first operand which beomes true).
 
-Inversely, for the `&&` operator, if the test is `true`, the `&&` expression results in the value of the *second operand* (`b`). If the test is `false`, the `&&` expression results in the value of the *first operand* (`a` or `c`).
+Inversely, for the `&&` operator, if the test is `true`, the `&&` expression results in the value of the *last operand* (`b`). If the test is `false`, the `&&` expression results in the value of the *first operand* (`a` or `c`).
 
 The result of a `||` or `&&` expression is always the underlying value of one of the operands, **not** the (possibly coerced) result of the test. In `c && b`, `c` is `null`, and thus falsy. But the `&&` expression itself results in `null` (the value in `c`), not in the coerced `false` used in the test.
 


### PR DESCRIPTION
It is not just the second operand but the last operand which is returned when all the conditions are true for &&.
Similarly, it is not just the second operand but the first operand, which is true, that is returned for ||.

`var a =42;
var b = "abc";
var c = null;
var d = 1;
var e = 0;`
`a && b && d; //1`
`e ||  c ||  a; //42`