### PR TITLE
one word is missing from chapter 6

### DIFF
--- a/scope-closures/ch6.md
+++ b/scope-closures/ch6.md
@@ -691,6 +691,6 @@ The point of lexical scoping rules in a programming language is so we can approp
 
 And one of the most important organizational techniques is to ensure that no variable is over-exposed to unnecessary scopes (POLE). Hopefully you now appreciate block scoping much more deeply than before.
 
-Hopefully by you feel like you're standing on much more solid ground with understanding lexical scope. From that base, the next chapter jumps into the weighty topic of closure.
+Hopefully by now you feel like you're standing on much more solid ground with understanding lexical scope. From that base, the next chapter jumps into the weighty topic of closure.
 
 [^POLP]: *Principle of Least Privilege*, https://en.wikipedia.org/wiki/Principle_of_least_privilege, 3 March 2020.


### PR DESCRIPTION
Sentence "Hopefully by you feel like you're standing on much more solid ground with understanding lexical scope. " change to
"Hopefully by now you feel like you're standing on much more solid ground with understanding lexical scope. "

One word "now" is missing from the original sentence in this chapter

**Yes, I promise I've read the [Contributions Guidelines](https://github.com/getify/You-Dont-Know-JS/blob/master/CONTRIBUTING.md)** (please feel free to remove this line).

Specifically quoting these guidelines regarding typos:

> Typos?
>
> Please don't worry about minor text typos. These will almost certainly be caught during the editing process.
>
> If you're going to submit a PR for typo fixes, please be measured in doing so by collecting several small changes into a single PR (in separate commits). Or, **just don't even worry about them for now,** because we'll get to them later. I promise.

----

**Please type "I already searched for this issue":**

**Edition:** (pull requests not accepted for previous editions)

**Book Title:**

**Chapter:**

**Section Title:**

**Topic:**
