### PR TITLE
Rearrange an order of TOC in get-started

### DIFF
--- a/get-started/toc.md
+++ b/get-started/toc.md
@@ -22,10 +22,10 @@
     * How We Organize in JS
     * The Rabbit Hole Deepens
 * Chapter 3: Digging To The Roots Of JS
+    * Iteration
     * Closure
     * `this` Keyword
     * Prototypes
-    * Iteration
     * Asking "Why?"
 * Chapter 4: The Bigger Picture
     * Pillar 1: Scope and Closure


### PR DESCRIPTION
Rearrange the order of TOC in `get-started`.

Related issue: #1659 

**Yes, I promise I've read the [Contributions Guidelines](https://github.com/getify/You-Dont-Know-JS/blob/master/CONTRIBUTING.md)** (please feel free to remove this line).

Specifically quoting these guidelines regarding typos:

> Typos?
>
> Please don't worry about minor text typos. These will almost certainly be caught during the editing process.
>
> If you're going to submit a PR for typo fixes, please be measured in doing so by collecting several small changes into a single PR (in separate commits). Or, **just don't even worry about them for now,** because we'll get to them later. I promise.

----

**Please type "I already searched for this issue":**

**Edition:** (pull requests not accepted for previous editions)

**Book Title:**

**Chapter:**

**Section Title:**

**Topic:**
