### PR TITLE
typo fix: indisputedly -> indisputably

### DIFF
--- a/scope-closures/ch1.md
+++ b/scope-closures/ch1.md
@@ -162,7 +162,7 @@ It's hard to imagine a production-quality JS engine going to all the trouble of 
 
 Many have endeavored to split hairs with this terminology, as there's plenty of nuance and "well, actually..." interjections floating around. But in spirit and in practice, what the engine is doing in processing JS programs is **much more alike compilation** than not.
 
-Classifying JS as a compiled language is not concerned with the distribution model for its binary (or byte-code) executable representations, but rather in keeping a clear distinction in our minds about the phase where JS code is processed and analyzed; this phase observably and indisputedly happens *before* the code starts to be executed.
+Classifying JS as a compiled language is not concerned with the distribution model for its binary (or byte-code) executable representations, but rather in keeping a clear distinction in our minds about the phase where JS code is processed and analyzed; this phase observably and indisputably happens *before* the code starts to be executed.
 
 We need proper mental models of how the JS engine treats our code if we want to understand JS and scope effectively.
 


### PR DESCRIPTION
Specifically quoting these guidelines regarding typos:

> Typos?
>
> Please don't worry about minor text typos. These will almost certainly be caught during the editing process.
>
> If you're going to submit a PR for typo fixes, please be measured in doing so by collecting several small changes into a single PR (in separate commits). Or, **just don't even worry about them for now,** because we'll get to them later. I promise.

----

**Please type "I already searched for this issue":**
I already searched for this issue

**Edition:** (pull requests not accepted for previous editions)
2nd

**Book Title:**
Scope & Closures

**Chapter:**
1

**Section Title:**
Compiling Code

**Topic:**
Typo fix: "indisputedly" is not a word https://www.merriam-webster.com/thesaurus/indisputably