### PR TITLE
Update Ch8. Custom Change Events section. Fix calc

### DIFF
--- a/es6 & beyond/ch8.md
+++ b/es6 & beyond/ch8.md
@@ -241,8 +241,8 @@ Object.observe(
 
 changeObj( 3, 11 );
 
-obj.a;			// 12
-obj.b;			// 30
+obj.a;			// 6
+obj.b;			// 33
 obj.c;			// 3
 ```
 


### PR DESCRIPTION
The original code shows:
```
obj.a;			// 12
obj.b;			// 30
obj.c;			// 3
```

But I made the calculation and the result must be:
```
obj.a;			// 6
obj.b;			// 33
obj.c;			// 3
```

Because we call to `changeObj( 3, 11 );` and:
```
	obj.a = a * 2;
	obj.b = b * 3;
```

The final value of the property `c` is OK because `a + b + old value of c` is `6 + 33 + 3` that is `42`.

Thanks!

**Yes, I promise I've read the [Contributions Guidelines](https://github.com/getify/You-Dont-Know-JS/blob/master/CONTRIBUTING.md)** (please feel free to remove this line).

Specifically quoting these guidelines regarding typos:

> Typos?
>
> Please don't worry about minor text typos. These will almost certainly be caught during the editing process.
>
> If you're going to submit a PR for typo fixes, please be measured in doing so by collecting several small changes into a single PR (in separate commits). Or, **just don't even worry about them for now,** because we'll get to them later. I promise.

----

**Please type "I already searched for this issue":**

**Edition:** (pull requests not accepted for previous editions)

**Book Title:**

**Chapter:**

**Section Title:**

**Topic:**
