### PR TITLE
Missing word grammar error in Ch. 3's `this` Keyword section

### DIFF
--- a/get-started/ch3.md
+++ b/get-started/ch3.md
@@ -267,7 +267,7 @@ If you're still feeling unclear or shaky about closure, the majority of Book 2, 
 
 ## `this` Keyword
 
-One of JS's most powerful mechanisms is also one of its most misunderstood: the `this` keyword. One common misconception is that a function's `this` refers to the function itself. Because of how `this` works in other languages, another misconception is that `this` points the instance that a method belongs to. Both are incorrect.
+One of JS's most powerful mechanisms is also one of its most misunderstood: the `this` keyword. One common misconception is that a function's `this` refers to the function itself. Because of how `this` works in other languages, another misconception is that `this` points to the instance that a method belongs to. Both are incorrect.
 
 As discussed previously, when a function is defined, it is *attached* to its enclosing scope via closure. Scope is the set of rules that controls how references to variables are resolved.
 


### PR DESCRIPTION
I already searched for this issue

**Edition:** 2nd

**Book Title:** Get Started

**Chapter:** 3

**Section Title:** `this` Keyword

**Topic:** Grammar error ([missing word](https://owl.excelsior.edu/grammar-essentials/common-errors/common-errors-missing-word/))

```
- another misconception is that `this` points the instance...
+ another misconception is that `this` points to the instance...
```