### PR TITLE
Fix grammar error (extra word)

### DIFF
--- a/scope-closures/ch5.md
+++ b/scope-closures/ch5.md
@@ -530,7 +530,7 @@ The term coined by TC39 to refer to this *period of time* from the entering of a
 
 The TDZ is the time window where a variable exists but is still uninitialized, and therefore cannot be accessed in any way. Only the execution of the instructions left by *Compiler* at the point of the original declaration can do that initialization. After that moment, the TDZ is done, and the variable is free to be used for the rest of the scope.
 
-A `var` also has technically has a TDZ, but it's zero in length and thus unobservable to our programs! Only `let` and `const` have an observable TDZ.
+A `var` also technically has a TDZ, but it's zero in length and thus unobservable to our programs! Only `let` and `const` have an observable TDZ.
 
 By the way, "temporal" in TDZ does indeed refer to *time* not *position in code*. Consider:
 


### PR DESCRIPTION
**Please type "I already searched for this issue":** "I already searched for this issue"

**Edition:** (pull requests not accepted for previous editions) 2nd

**Book Title:** You Don't Know JS Yet: Scope & Closures - 2nd Edition

**Chapter:** Chapter 5: The (Not So) Secret Lifecycle of Variables

**Section Title:** Uninitialized Variables (aka, TDZ)

**Topic:** Grammar error

```
- A `var` also has technically has a TDZ...
+ A `var` also technically has a TDZ...
```