### PR TITLE
replaced 2020 with 2021 for license & copyright

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,6 @@ But **PLEASE** read the [Contributions Guidelines](CONTRIBUTING.md) carefully be
 
 ## License & Copyright
 
-The materials herein are all &copy; 2019-2020 Kyle Simpson.
+The materials herein are all &copy; 2019-2021 Kyle Simpson.
 
 <a rel="license" href="http://creativecommons.org/licenses/by-nc-nd/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-nd/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-nc-nd/4.0/">Creative Commons Attribution-NonCommercial-NoDerivs 4.0 Unported License</a>.


### PR DESCRIPTION
I already searched for this issue
Hi,
I have the replaced the year 2020 with 2021 in the README.md's License and Copyright section. Kindly accept the pull request.
Thank you