### PR TITLE
fix: closure example

### DIFF
--- a/scope-closures/apA.md
+++ b/scope-closures/apA.md
@@ -651,7 +651,7 @@ function getStudents(data) {
         let id = `student-${ record.id }`;
         studentRecords.push({
             id,
-            record.name
+            name: record.name
         });
     }
 


### PR DESCRIPTION
**Yes, I promise I've read the [Contributions Guidelines](https://github.com/getify/You-Dont-Know-JS/blob/master/CONTRIBUTING.md)** (please feel free to remove this line).

Specifically quoting these guidelines regarding typos:

> Typos?
>
> Please don't worry about minor text typos. These will almost certainly be caught during the editing process.
>
> If you're going to submit a PR for typo fixes, please be measured in doing so by collecting several small changes into a single PR (in separate commits). Or, **just don't even worry about them for now,** because we'll get to them later. I promise.

----

**Please type "I already searched for this issue":**
I already searched for this issue
**Edition:** (pull requests not accepted for previous editions)
2nd
**Book Title:**
Scope & Closures
**Chapter:**
apA.md
**Section Title:**
 `var` *and* `let`
**Topic:**
example code

The example code will cause a SyntaxError: Unexpected token '.'  by `record.name`.

```js
function getStudents(data) {
    var studentRecords = [];

    for (let record of data.records) {
        let id = `student-${ record.id }`;
        studentRecords.push({
            id,
            record.name  // <---- SyntaxError: Unexpected token '.', fixed this line to `name: record.name`
        });
    }

    return studentRecords;
}
```
```
             record.name
                  ^

SyntaxError: Unexpected token '.'
    at wrapSafe (internal/modules/cjs/loader.js:1001:16)
    at Module._compile (internal/modules/cjs/loader.js:1049:27)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
    at Module.load (internal/modules/cjs/loader.js:950:32)
    at Function.Module._load (internal/modules/cjs/loader.js:790:12)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:76:12)
    at internal/main/run_main_module.js:17:47
```