### PR TITLE
view shallow copy output

### DIFF
--- a/get-started/ch3.md
+++ b/get-started/ch3.md
@@ -102,6 +102,8 @@ Since arrays are iterables, we can shallow-copy an array using iterator consumpt
 
 ```js
 var arrCopy = [ ...arr ];
+arrCopy;
+// [ 10, 20, 30 ]
 ```
 
 We can also iterate the characters in a string one at a time:


### PR DESCRIPTION
Just a addition so the reader knows what the output of this shallow copy is using the spread operator. As I myself was wondering if there is a difference between var arrCopy = [ ...arr ];
or arrCopy = arr;
Specifically quoting these guidelines regarding typos:

I already searched for this issue

**Edition:** (pull requests not accepted for previous editions)
2
**Book Title:**
get-started
**Chapter:**
3
**Section Title:**
Iterables
**Topic:**
