### PR TITLE
Object.entries(myObj) typo

### DIFF
--- a/objects-classes/ch1.md
+++ b/objects-classes/ch1.md
@@ -359,7 +359,7 @@ myObj = {
 };
 
 Object.entries(myObj);
-// [ ["favoriteNumber",42], ["isDeveloper",true], ["firstName":"Kyle"] ]
+// [ ["favoriteNumber",42], ["isDeveloper",true], ["firstName","Kyle"] ]
 ```
 
 Added in ES6, `Object.entries(..)` retieves this list of entries -- containing only owned an enumerable properties; see the "Property Descriptors" section in the next chapter -- from a source object.


### PR DESCRIPTION
 I already searched for this issue:

Line 362: `Object.entries(myObj)` should return `[ ["favoriteNumber",42], ["isDeveloper",true], ["firstName","Kyle"] ]`


**Yes, I promise I've read the Contributions Guidelines**
----

**Edition:** 2nd Edition

**Book Title:** Objects & Classes

**Chapter:** Chapter 1: Object Foundations

**Section Title:** Object Entries

**Topic:** Object Entries wrong output
