### PR TITLE
fix function capitalization in apA.md

### DIFF
--- a/scope-closures/apA.md
+++ b/scope-closures/apA.md
@@ -885,11 +885,11 @@ What about an IIF that does have external references, is that closure?
 
 ```js
 function printLabels(labels) {
-    var list = document.getElementByID("labelsList");
+    var list = document.getElementById("labelsList");
 
     labels.forEach(
         function renderLabel(label){
-            var li = document.createELement("li");
+            var li = document.createElement("li");
             li.innerText = label;
             list.appendChild(li);
         }
@@ -909,7 +909,7 @@ To understand why, consider this alternative form of `printLabels(..)`:
 
 ```js
 function printLabels(labels) {
-    var list = document.getElementByID("labelsList");
+    var list = document.getElementById("labelsList");
 
     for (let label of labels) {
         // just a normal function call in its own
@@ -920,7 +920,7 @@ function printLabels(labels) {
     // **************
 
     function renderLabel(label) {
-        var li = document.createELement("li");
+        var li = document.createElement("li");
         li.innerText = label;
         list.appendChild(li);
     }
@@ -937,7 +937,7 @@ By the way, Chapter 7 briefly mentioned partial application and currying (which 
 
 ```js
 function printLabels(labels) {
-    var list = document.getElementByID("labelsList");
+    var list = document.getElementById("labelsList");
     var renderLabel = renderTo(list);
 
     // definitely closure this time!
@@ -947,7 +947,7 @@ function printLabels(labels) {
 
     function renderTo(list) {
         return function createLabel(label){
-            var li = document.createELement("li");
+            var li = document.createElement("li");
             li.innerText = label;
             list.appendChild(li);
         };


### PR DESCRIPTION
Addresses #1784 

I already searched for this issue.

**Edition:** 2nd

**Book Title:** Scope & Closures

**Chapter:** Appendix A: Exploring Further

**Section Title:** Are Synchronous Callbacks Still Closures?

**Problem:** Function name capitalization throws error. `document.getElementByID` should be `document.getElementById`, note the lowercase `d` at the end. `document.createELement` should be `document.createElement`, note the lowercase `l`.

Link to file with error: https://github.com/getify/You-Dont-Know-JS/blob/fcbd9b8d965f9c97508906c5739d4e919b067b0d/scope-closures/apA.md#synchronous-closure