### PR TITLE
Replace the "As mentioned earlier" part in ch1.md

### DIFF
--- a/get-started/ch2.md
+++ b/get-started/ch2.md
@@ -123,7 +123,7 @@ You won't encounter direct usage of symbols very often in typical JS programs. T
 
 Besides primitives, the other value type in JS is an object value.
 
-As mentioned earlier, arrays are a special type of object that's comprised of an ordered and numerically indexed list of data:
+It is worth mentioning that JS arrays are a special type of object that's comprised of an ordered and numerically indexed list of data:
 
 ```js
 var names = [ "Frank", "Kyle", "Peter", "Susan" ];


### PR DESCRIPTION
Maybe I'm wrong (hope I'm not), I don't remember any mentions about an array type at that point of the book. I've tried to find it, but I found nothing. It might be an artefact of the original book (the 1st edition).

So I'd replace the "As mentioned earlier" part with something not confusing. I'm not a native English, so probably you have a better idea for the replacement.

"I already searched for this issue"

**Edition:** 2nd

**Book Title:** You Don't Know JS Yet: Get Started

**Chapter:** 2

**Section Title:** Values

**Topic:** Arrays And Objects
