### PR TITLE
fix(typo): add missing 'var' to code snippet

### DIFF
--- a/scope-closures/ch1.md
+++ b/scope-closures/ch1.md
@@ -207,7 +207,7 @@ For the JS engine to properly handle a program's variables, it must first label 
 What makes a variable a *target*? Consider:
 
 ```js
-students = [ // ..
+var students = [ // ..
 ```
 
 This statement is clearly an assignment operation; remember, the `var students` part is handled entirely as a declaration at compile time, and is thus irrelevant during execution; we left it out for clarity and focus. Same with the `nextStudent = getStudentName(73)` statement.


### PR DESCRIPTION
Just corrected a missing 'var' in the code snippet. I know _minor_ typos are to be ignored, but the following paragraph directly quotes this code snippet and declares it as containing 'var'--please ignore if my justification is not up to par. 

On the other hand, I saw a few others that I consider minor and can wrap them up in this PR or just leave them. This is the only one that stood out as pertinent to me. 

**Yes, I promise I've read the [Contributions Guidelines](https://github.com/getify/You-Dont-Know-JS/blob/master/CONTRIBUTING.md)**

Specifically quoting these guidelines regarding typos:

> Typos?
>
> Please don't worry about minor text typos. These will almost certainly be caught during the editing process.
>
> If you're going to submit a PR for typo fixes, please be measured in doing so by collecting several small changes into a single PR (in separate commits). Or, **just don't even worry about them for now,** because we'll get to them later. I promise.

----

**Please type "I already searched for this issue":**
I already searched for this issue

**Edition:** (pull requests not accepted for previous editions)
2/Lastest

**Book Title:**
scope-closures

**Chapter:**
1

**Section Title:**
Compiler Speak 

**Topic:**
Targets