### PR TITLE
Update ch3.md

### DIFF
--- a/get-started/ch3.md
+++ b/get-started/ch3.md
@@ -98,7 +98,7 @@ for (let val of arr) {
 // Array value: 30
 ```
 
-Since arrays are iterables, we can shallow-copy an array using iterator consumption via the `...` spread operator:
+Since arrays are iterables, we can deep-copy a one dimension array using iterator consumption via the `...` spread operator:
 
 ```js
 var arrCopy = [ ...arr ];


### PR DESCRIPTION
Fixed the purpose of the spread operator in one dimension arrays (deep copies).

**Please type "I already searched for this issue":** I already searched for this issue

**Edition:** (pull requests not accepted for previous editions) - 2nd

**Book Title:** Get Started 2nd Edition

**Chapter:** - Chapter 3: Digging to the roots of JS

**Section Title:** - Consuming Iterators

**Topic:** spread operator
