### PR TITLE
Reordering of "Why Closure?" and "An Alternative Perspective" in the toc

### DIFF
--- a/scope-closures/toc.md
+++ b/scope-closures/toc.md
@@ -42,8 +42,8 @@
 * Chapter 7: Using Closures
     * See the Closure
     * The Closure Lifecycle and Garbage Collection (GC)
-    * Why Closure?
     * An Alternative Perspective
+    * Why Closure?
     * Closer to Closure
 * Chapter 8: The Module Pattern
     * Encapsulation and Least Exposure (POLE)


### PR DESCRIPTION
**Yes, I promise I've read the [Contributions Guidelines](https://github.com/getify/You-Dont-Know-JS/blob/master/CONTRIBUTING.md)** (please feel free to remove this line).

Specifically quoting these guidelines regarding typos:

> Typos?
>
> Please don't worry about minor text typos. These will almost certainly be caught during the editing process.
>
> If you're going to submit a PR for typo fixes, please be measured in doing so by collecting several small changes into a single PR (in separate commits). Or, **just don't even worry about them for now,** because we'll get to them later. I promise.

----

**Please type "I already searched for this issue":** I already searched for this issue

**Edition:** 2nd Edition

**Book Title:** scope-closures

**Chapter:** Chapter 7: Using Closures

**Section Title:** Why Closure?

**Topic:** Reordering of "Why Closure?" and "An Alternative Perspective" in the toc

In the course of translation I noticed that "[An Alternative Perspective](https://github.com/getify/You-Dont-Know-JS/blob/85b2e6c5fa03b95d044015d6e44b72b8beb6a53b/scope-closures/ch7.md?plain=1#L649)" in the toc should precede "[Why Closure?](https://github.com/getify/You-Dont-Know-JS/blob/85b2e6c5fa03b95d044015d6e44b72b8beb6a53b/scope-closures/ch7.md?plain=1#L715)"

Close: #1844
