### PR TITLE
added comma to prevent syntax error in code snippet

### DIFF
--- a/objects-classes/ch1.md
+++ b/objects-classes/ch1.md
@@ -681,7 +681,7 @@ const { one, two, three } =
     // transport for multiple input values
     formatValues({
        one: "Kyle",
-       two: "Simpson"
+       two: "Simpson",
        three: "getify"
     });
 


### PR DESCRIPTION
**Yes, I promise I've read the [Contributions Guidelines](https://github.com/getify/You-Dont-Know-JS/blob/master/CONTRIBUTING.md)** (please feel free to remove this line).

Specifically quoting these guidelines regarding typos:

> Typos?
>
> Please don't worry about minor text typos. These will almost certainly be caught during the editing process.
>
> If you're going to submit a PR for typo fixes, please be measured in doing so by collecting several small changes into a single PR (in separate commits). Or, **just don't even worry about them for now,** because we'll get to them later. I promise.

----

**Please type "I already searched for this issue":**
I already searched for this issue
**Edition:** (pull requests not accepted for previous editions)
2nd
**Book Title:**
Objects & Classes
**Chapter:**
ch1
**Section Title:**
Temporary Containers
**Topic:**
example code snippet  
Uncaught SyntaxError: Unexpected identifier 'three'
```js
function formatValues({ one, two, three }) {
    // the actual object passed in as an
    // argument is not accessible, since
    // we destructured it into three
    // separate variables

    one = one.toUpperCase();
    two = `--${two}--`;
    three = three.substring(0,5);

    // this object is only to transport
    // all three values in a single
    // return statement
    return { one, two, three };
}

// destructuring the return value from
// the function, because that returned
// object is just a temporary container
// to transport us multiple values
const { one, two, three } =

    // this object argument is a temporary
    // transport for multiple input values
    formatValues({
       one: "Kyle",
       two: "Simpson"  // <--- Uncaught SyntaxError: Unexpected identifier 'three'; added comma 
       three: "getify"
    });

one;     // "KYLE"
two;     // "--Simpson--"
three;   // "getif"
```
