### PR TITLE
Typo fix for lessThen method

### DIFF
--- a/types-grammar/ch4.md
+++ b/types-grammar/ch4.md
@@ -398,7 +398,7 @@ At least now we've answered the age old question of *which comes first*?!
 
 #### Numeric Comparison
 
-For numeric comparisons, `IsLessThan()` defers to either the `Number:lessThan()` or `BigInt.lessThan()` operation[^NumericAbstractOps], respectively:
+For numeric comparisons, `IsLessThan()` defers to either the `Number:lessThan()` or `BigInt:lessThan()` operation[^NumericAbstractOps], respectively:
 
 ```
 IsLessThan(41,42, /*LeftFirst=*/ true );         // true


### PR DESCRIPTION
Added consistent scoping syntax for the lessThen method

**Yes, I promise I've read the [Contributions Guidelines](https://github.com/getify/You-Dont-Know-JS/blob/master/CONTRIBUTING.md)** (please feel free to remove this line).

Specifically quoting these guidelines regarding typos:

> Typos?
>
> Please don't worry about minor text typos. These will almost certainly be caught during the editing process.
>
> If you're going to submit a PR for typo fixes, please be measured in doing so by collecting several small changes into a single PR (in separate commits). Or, **just don't even worry about them for now,** because we'll get to them later. I promise.

----

**Please type "I already searched for this issue":** I already searched for this issue

**Edition:** (pull requests not accepted for previous editions) 2nd

**Book Title:** [types-grammar](https://github.com/getify/You-Dont-Know-JS/tree/2nd-ed/types-grammar)

**Chapter:** 4th

**Section Title:** Relational Comparison

**Topic:** Numeric Comparison
