### PR TITLE
Update ch3.md (Fix typo issue)

### DIFF
--- a/types & grammar/ch3.md
+++ b/types & grammar/ch3.md
@@ -31,7 +31,7 @@ It *is* true that each of these natives can be used as a native constructor. But
 ```js
 var a = new String( "abc" );
 
-typeof a; // "object" ... not "String"
+typeof a; // "object" ... not "string"
 
 a instanceof String; // true
 


### PR DESCRIPTION
"string" should be write in lower case when is print out via 'typeof' operator.

**Yes, I promise I've read the [Contributions Guidelines](https://github.com/getify/You-Dont-Know-JS/blob/master/CONTRIBUTING.md)** (please feel free to remove this line).

Specifically quoting these guidelines regarding typos:

> Typos?
>
> Please don't worry about minor text typos. These will almost certainly be caught during the editing process.
>
> If you're going to submit a PR for typo fixes, please be measured in doing so by collecting several small changes into a single PR (in separate commits). Or, **just don't even worry about them for now,** because we'll get to them later. I promise.

----

**Please type "I already searched for this issue":**

**Edition:** (pull requests not accepted for previous editions)

**Book Title:**

**Chapter:**

**Section Title:**

**Topic:**
